### PR TITLE
fix: resolve CI editable installation and security vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
           # Audit the environment - includes both package deps and pip-audit
           # Note: Ideally we'd only audit package deps, but pip-audit doesn't support that granularity
           # If this fails due to pip-audit vulns (not package deps), consider using --ignore-vuln
-          uv run --python .venv-audit pip-audit --desc on --skip-editable
+          uv run --python .venv-audit pip-audit --desc on
       - name: Check package description will render on PyPI
         run: |
           uv tool install twine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "types-xmltodict", # Type stubs for xmltodict
     "influxdb>=5.3.2",
     "pydantic>=2.0.0,<3.0", # Modern data validation with type hints
+    "urllib3>=2.6.3", # Security: CVE fixes in 2.6.3+
+    "filelock>=3.20.1", # Security: CVE fixes in 3.20.1+
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -314,11 +314,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.19.1"
+version = "3.20.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/bb/0ab3e58d22305b6f5440629d20683af28959bf793d98d11950e305c1c326/filelock-3.19.1.tar.gz", hash = "sha256:66eda1888b0171c998b35be2bcc0f6d75c388a7ce20c3f3f37aa8e96c2dddf58", size = 17687, upload-time = "2025-08-14T16:56:03.016Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/e0/a75dbe4bca1e7d41307323dad5ea2efdd95408f74ab2de8bd7dba9b51a1a/filelock-3.20.2.tar.gz", hash = "sha256:a2241ff4ddde2a7cebddf78e39832509cb045d18ec1a09d7248d6bfc6bfbbe64", size = 19510, upload-time = "2026-01-02T15:33:32.582Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/14/42b2651a2f46b022ccd948bca9f2d5af0fd8929c4eec235b8d6d844fbe67/filelock-3.19.1-py3-none-any.whl", hash = "sha256:d38e30481def20772f5baf097c122c3babc4fcdb7e14e57049eb9d88c6dc017d", size = 15988, upload-time = "2025-08-14T16:56:01.633Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/30/ab407e2ec752aa541704ed8f93c11e2a5d92c168b8a755d818b74a3c5c2d/filelock-3.20.2-py3-none-any.whl", hash = "sha256:fbba7237d6ea277175a32c54bb71ef814a8546d8601269e1bfc388de333974e8", size = 16697, upload-time = "2026-01-02T15:33:31.133Z" },
 ]
 
 [[package]]
@@ -403,6 +403,7 @@ name = "kpi-calculator"
 source = { editable = "." }
 dependencies = [
     { name = "coloredlogs" },
+    { name = "filelock" },
     { name = "influxdb" },
     { name = "numpy" },
     { name = "pandas" },
@@ -410,6 +411,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyesdl" },
     { name = "types-xmltodict" },
+    { name = "urllib3" },
     { name = "xmltodict" },
 ]
 
@@ -466,13 +468,15 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "coloredlogs", specifier = "~=15.0.1" },
+    { name = "filelock", specifier = ">=3.20.1" },
     { name = "influxdb", specifier = ">=5.3.2" },
     { name = "numpy", specifier = ">=2.1.0,<3.0" },
     { name = "pandas", specifier = ">=2.2.2,<3.0" },
     { name = "pandas-stubs" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0" },
-    { name = "pyesdl", specifier = "~=25.5.1" },
+    { name = "pyesdl", specifier = "~=25.7" },
     { name = "types-xmltodict" },
+    { name = "urllib3", specifier = ">=2.6.3" },
     { name = "xmltodict", specifier = "==0.14.2" },
 ]
 
@@ -1072,14 +1076,14 @@ wheels = [
 
 [[package]]
 name = "pyesdl"
-version = "25.5.1"
+version = "25.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyecore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/55/f44c9f5a280c62bddda7ff102a7cca4842c3f3bfed6cc7feb3440bf781d5/pyesdl-25.5.1.tar.gz", hash = "sha256:242d2bf4677aee35bb64d4a6fa474777b890c5c7764413dffa16cb68d32472ca", size = 94090, upload-time = "2025-05-09T11:29:37.11Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/45/4377eb85eac355a247824f7a4cb94804bbe03a7a27fd26a83d33ebdb9e23/pyesdl-25.12.1.tar.gz", hash = "sha256:54bc48203e7f740688c7adea5525740ea70a0ce24ea974ea010c19034ee81c0c", size = 95270, upload-time = "2025-12-19T09:44:27.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/e9/d45dc6e3648cd0549a5a995bed4c8f043ee7cc2fb045b3517d5798547595/pyesdl-25.5.1-py3-none-any.whl", hash = "sha256:89d59c82ca4efae617c305163ae61fb27c148bfa2f0dcd61c74aca9ae6b1dd3b", size = 84517, upload-time = "2025-05-09T11:29:35.339Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/59/dd22d157a3c782d25a253d8809b686564fa5385aa2aa3efe07224847d1cf/pyesdl-25.12.1-py3-none-any.whl", hash = "sha256:1448c82e7c8df500b69aa86154aa9d166a7f16c526ca52d8196524bca41c40ad", size = 85642, upload-time = "2025-12-19T09:44:25.806Z" },
 ]
 
 [[package]]
@@ -1438,11 +1442,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Fix CI editable installation error and security vulnerabilities

#### CI Pipeline Fix
- Use `--no-editable` flag in `uv sync` to prevent editable installation in CI
- Remove `--skip-editable` flag from pip-audit to allow scanning all packages

#### Security Updates
- **urllib3**: 2.5.0 → 2.6.3
  - Fixes decompression bomb vulnerabilities (GHSA-gm62-xv2j-4w53, GHSA-2xpw-w6gg-jr37, GHSA-38jv-5279-wg99)
- **filelock**: 3.19.1 → 3.20.2
  - Fixes TOCTOU race condition vulnerability (GHSA-w853-jp5j-5j7f)
- **pyesdl**: 25.5.1 → 25.12.1 (compatible with ~=25.7 constraint)

