### PR TITLE
feat: add support for loading ESDL from string content

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ exclude = ['.venv/*', 'venv/*', 'doc/*', 'ci/*']
 
 # mypy per-module options:
 [[tool.mypy.overrides]]
-module = ["unit_test.*", "coloredlogs.*", "pandas.*", "xmltodict.*", "esdl.*", "esdl.esdl_handler.*"]
+module = ["unit_test.*", "coloredlogs.*", "pandas.*", "xmltodict.*", "esdl.*", "esdl.esdl_handler.*", "jinja2.*"]
 check_untyped_defs = true
 ignore_missing_imports = true
 

--- a/src/kpicalculator/adapters/esdl_adapter.py
+++ b/src/kpicalculator/adapters/esdl_adapter.py
@@ -81,11 +81,11 @@ class EsdlAdapter(BaseAdapter):
         Raises:
             TypeError: If source is not a file path (MESIDO/Simulator not supported)
         """
-        # ESDL adapter only supports file paths
         if not isinstance(source, (str, Path)):
             raise TypeError(f"ESDL adapter only supports file paths, got {type(source)}")
 
         esdl_file = str(source)
+
         # Validate inputs with security checks
         validation_result = self.validate_source(esdl_file)
         if not validation_result.is_valid:
@@ -104,6 +104,101 @@ class EsdlAdapter(BaseAdapter):
         esh = EnergySystemHandler()
         es = esh.load_file(esdl_file)
 
+        # Derive model name from file path
+        model_name = Path(esdl_file).stem
+        if OPTIMAL_TOPOLOGY_SUFFIX in model_name[-20:]:
+            model_name = model_name[:-OPTIMAL_TOPOLOGY_SUFFIX_LENGTH]
+        if "mod" in model_name[-4:]:
+            model_name = model_name[:-MOD_SUFFIX_LENGTH]
+
+        return self._process_energy_system(
+            es=es,
+            model_name=model_name,
+            source_metadata={"esdl_file": esdl_file},
+            time_series_file=time_series_file,
+            timeseries_dataframes=timeseries_dataframes,
+            use_database_profiles=use_database_profiles,
+        )
+
+    def load_from_string(
+        self,
+        esdl_string: str,
+        timeseries_dataframes: dict[str, pd.DataFrame] | None = None,
+        use_database_profiles: bool = False,
+    ) -> EnergySystem:
+        """Load energy system data from ESDL XML string content.
+
+        This method allows loading ESDL data directly from a string without
+        needing a file. Useful for integration with systems that provide
+        ESDL content in memory (e.g., simulator_worker).
+
+        Costs are extracted from ESDL costInformation elements.
+
+        Note:
+            The default `use_database_profiles=False` reflects the typical use case
+            for string loading: in-memory workflows where time series data is provided
+            via `timeseries_dataframes` rather than fetched from a database.
+
+        Args:
+            esdl_string: ESDL XML content as a string
+            timeseries_dataframes: Optional dict mapping asset IDs to pandas DataFrames
+                with time-indexed energy/power data.
+            use_database_profiles: Whether to load InfluxDB profiles (default False
+                for in-memory workflows)
+
+        Returns:
+            EnergySystem object with costs from ESDL costInformation
+
+        Raises:
+            ValidationError: If esdl_string is empty or cannot be parsed
+        """
+        # Validate input
+        if not esdl_string or not esdl_string.strip():
+            raise ValidationError("ESDL string content cannot be empty")
+
+        # Parse ESDL string with error handling
+        esh = EnergySystemHandler()
+        try:
+            es = esh.load_from_string(esdl_string)
+        except Exception as e:
+            raise ValidationError(f"Failed to parse ESDL string: {e}") from e
+
+        # Use energy system name if available, otherwise default
+        model_name = es.name if es.name else "esdl_from_string"
+
+        return self._process_energy_system(
+            es=es,
+            model_name=model_name,
+            source_metadata={"esdl_source": "string"},
+            time_series_file=None,
+            timeseries_dataframes=timeseries_dataframes,
+            use_database_profiles=use_database_profiles,
+        )
+
+    def _process_energy_system(
+        self,
+        es: esdl.EnergySystem,
+        model_name: str,
+        source_metadata: dict[str, str],
+        time_series_file: str | None,
+        timeseries_dataframes: dict[str, pd.DataFrame] | None,
+        use_database_profiles: bool,
+    ) -> EnergySystem:
+        """Process a loaded ESDL EnergySystem into our internal EnergySystem model.
+
+        This is the shared processing logic used by both load_data() and load_from_string().
+
+        Args:
+            es: The pyesdl EnergySystem object
+            model_name: Name for the energy system
+            source_metadata: Metadata about the source (file path or "string")
+            time_series_file: Optional XML time series file path
+            timeseries_dataframes: Optional dict of asset ID to DataFrame mappings
+            use_database_profiles: Whether to load InfluxDB profiles
+
+        Returns:
+            EnergySystem object with processed assets and costs
+        """
         # Load time series data using centralized TimeSeriesManager
         source_priority = ["dataframes"]
         if use_database_profiles:
@@ -135,18 +230,11 @@ class EsdlAdapter(BaseAdapter):
             except Exception as e:
                 self.logger.warning(f"Failed to create XML time series adapter: {e}")
 
-        # Create energy system
-        model_name = Path(esdl_file).stem
-        if OPTIMAL_TOPOLOGY_SUFFIX in model_name[-20:]:
-            model_name = model_name[:-OPTIMAL_TOPOLOGY_SUFFIX_LENGTH]
-        if "mod" in model_name[-4:]:
-            model_name = model_name[:-MOD_SUFFIX_LENGTH]
-
         energy_system = EnergySystem(
             name=model_name,
             assets=[],
             unit_conversion=self.unit_conversions or {},
-            source_metadata={"esdl_file": str(esdl_file)},
+            source_metadata=source_metadata,
         )
 
         # Process assets

--- a/src/kpicalculator/kpi_manager.py
+++ b/src/kpicalculator/kpi_manager.py
@@ -96,6 +96,33 @@ class KpiManager:
         )
         self.source_esdl_file = esdl_file
 
+    def load_from_esdl_string(
+        self,
+        esdl_string: str,
+        timeseries_dataframes: dict[str, pd.DataFrame] | None = None,
+    ) -> None:
+        """Load energy system data from ESDL XML string content.
+
+        This method allows loading ESDL data directly from a string without
+        needing a temporary file. Useful for integration with systems that
+        provide ESDL content in memory (e.g., simulator_worker).
+
+        Cost data is extracted from ESDL costInformation elements.
+
+        Args:
+            esdl_string: ESDL XML content as a string
+            timeseries_dataframes: Optional dict mapping asset IDs to pandas
+                DataFrames with time-indexed energy/power data.
+        """
+        from .adapters.esdl_adapter import EsdlAdapter
+
+        adapter = EsdlAdapter(self.unit_conversion)
+        self.energy_system = adapter.load_from_string(
+            esdl_string,
+            timeseries_dataframes=timeseries_dataframes,
+        )
+        self.source_esdl_file = None
+
     def load_from_simulator(self, simulator_data: Any) -> None:
         """Load energy system data from simulator data structure.
 

--- a/unit_test/test_kpi_calculator.py
+++ b/unit_test/test_kpi_calculator.py
@@ -50,5 +50,99 @@ class NewKpiCalculatorTest(unittest.TestCase):
         )
 
 
+class EsdlStringLoadingTest(unittest.TestCase):
+    """Tests for loading ESDL from string content instead of file path."""
+
+    def test_load_from_esdl_string_empty_raises_error(self) -> None:
+        """Test that empty ESDL string raises ValidationError."""
+        from kpicalculator.exceptions import ValidationError
+
+        unit_conv = DATA_DIR / "unit_conversion.csv"
+        kpi_manager = KpiManager(str(unit_conv))
+
+        with self.assertRaises(ValidationError):
+            kpi_manager.load_from_esdl_string("")
+
+        with self.assertRaises(ValidationError):
+            kpi_manager.load_from_esdl_string("   ")
+
+    def test_load_from_esdl_string_invalid_raises_error(self) -> None:
+        """Test that invalid ESDL string raises ValidationError."""
+        from kpicalculator.exceptions import ValidationError
+
+        unit_conv = DATA_DIR / "unit_conversion.csv"
+        kpi_manager = KpiManager(str(unit_conv))
+
+        with self.assertRaises(ValidationError):
+            kpi_manager.load_from_esdl_string("not valid xml")
+
+    def test_load_from_esdl_string_uses_esdl_name(self) -> None:
+        """Test that model name is derived from ESDL name attribute."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        esdl_string = esdl_file.read_text(encoding="utf-8")
+
+        unit_conv = DATA_DIR / "unit_conversion.csv"
+        kpi_manager = KpiManager(str(unit_conv))
+        kpi_manager.load_from_esdl_string(esdl_string)
+
+        # The test ESDL has name="KPI_calc_test_model"
+        self.assertEqual(kpi_manager.energy_system.name, "KPI_calc_test_model")
+
+    def test_load_from_esdl_string_fallback_name(self) -> None:
+        """Test that model name falls back to default when ESDL has no name."""
+        # Minimal valid ESDL without a name attribute
+        esdl_no_name = """<?xml version='1.0' encoding='UTF-8'?>
+        <esdl:EnergySystem xmlns:esdl="http://www.tno.nl/esdl" id="test-id">
+            <instance id="instance-1">
+                <area id="area-1"/>
+            </instance>
+        </esdl:EnergySystem>"""
+
+        unit_conv = DATA_DIR / "unit_conversion.csv"
+        kpi_manager = KpiManager(str(unit_conv))
+        kpi_manager.load_from_esdl_string(esdl_no_name)
+
+        self.assertEqual(kpi_manager.energy_system.name, "esdl_from_string")
+
+    def test_load_from_esdl_string_matches_file_loading(self) -> None:
+        """Test that string loading produces identical KPI results to file loading."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        unit_conv = DATA_DIR / "unit_conversion.csv"
+
+        # Load from file
+        file_manager = KpiManager(str(unit_conv))
+        file_manager.load_from_esdl(str(esdl_file))
+        file_results = file_manager.calculate_all_kpis(system_lifetime=40)
+
+        # Load from string
+        esdl_string = esdl_file.read_text(encoding="utf-8")
+        string_manager = KpiManager(str(unit_conv))
+        string_manager.load_from_esdl_string(esdl_string)
+
+        # Verify string loading sets correct state
+        self.assertIsNotNone(string_manager.energy_system)
+        self.assertIsNone(string_manager.source_esdl_file)
+
+        # Compare KPI results - should be identical
+        string_results = string_manager.calculate_all_kpis(system_lifetime=40)
+        self.assertAlmostEqual(
+            file_results["costs"]["capex"]["All"],
+            string_results["costs"]["capex"]["All"],
+            places=2,
+            msg="CAPEX mismatch between file and string loading",
+        )
+        self.assertEqual(
+            file_results["energy"]["consumption"],
+            string_results["energy"]["consumption"],
+            msg="Energy consumption mismatch between file and string loading",
+        )
+        self.assertAlmostEqual(
+            file_results["emissions"]["total"],
+            string_results["emissions"]["total"],
+            places=6,
+            msg="Emissions mismatch between file and string loading",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -471,7 +471,7 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.2.2,<3.0" },
     { name = "pandas-stubs" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0" },
-    { name = "pyesdl", specifier = "~=25.5.1" },
+    { name = "pyesdl", specifier = "~=25.7" },
     { name = "types-xmltodict" },
     { name = "xmltodict", specifier = "==0.14.2" },
 ]
@@ -1072,14 +1072,14 @@ wheels = [
 
 [[package]]
 name = "pyesdl"
-version = "25.5.1"
+version = "25.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyecore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/55/f44c9f5a280c62bddda7ff102a7cca4842c3f3bfed6cc7feb3440bf781d5/pyesdl-25.5.1.tar.gz", hash = "sha256:242d2bf4677aee35bb64d4a6fa474777b890c5c7764413dffa16cb68d32472ca", size = 94090, upload-time = "2025-05-09T11:29:37.11Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/45/4377eb85eac355a247824f7a4cb94804bbe03a7a27fd26a83d33ebdb9e23/pyesdl-25.12.1.tar.gz", hash = "sha256:54bc48203e7f740688c7adea5525740ea70a0ce24ea974ea010c19034ee81c0c", size = 95270, upload-time = "2025-12-19T09:44:27.118Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/e9/d45dc6e3648cd0549a5a995bed4c8f043ee7cc2fb045b3517d5798547595/pyesdl-25.5.1-py3-none-any.whl", hash = "sha256:89d59c82ca4efae617c305163ae61fb27c148bfa2f0dcd61c74aca9ae6b1dd3b", size = 84517, upload-time = "2025-05-09T11:29:35.339Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/59/dd22d157a3c782d25a253d8809b686564fa5385aa2aa3efe07224847d1cf/pyesdl-25.12.1-py3-none-any.whl", hash = "sha256:1448c82e7c8df500b69aa86154aa9d166a7f16c526ca52d8196524bca41c40ad", size = 85642, upload-time = "2025-12-19T09:44:25.806Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add `load_from_esdl_string()` method to KpiManager and `load_from_string()` to EsdlAdapter, enabling ESDL loading directly from string content without requiring a file path.

- Extract shared processing logic into _process_energy_system()
- Add input validation for empty/unparseable ESDL strings
- Default use_database_profiles=False for in-memory workflows
- Use ESDL name attribute when available, fallback to "esdl_from_string"

This enables simulator-worker integration.