### PR TITLE
fix: map DataFrame time series using composite keys

### DIFF
--- a/src/kpicalculator/adapters/time_series_manager.py
+++ b/src/kpicalculator/adapters/time_series_manager.py
@@ -5,9 +5,8 @@ import logging
 
 import pandas as pd
 from esdl import esdl
-from esdl.profiles.profilemanager import ProfileManager, ProfileType
 
-from ..common.constants import COMPOSITE_KEY_SEPARATOR
+from ..common.constants import COMPOSITE_KEY_SEPARATOR, KNOWN_TIME_SERIES_FIELDS
 from ..security.credential_manager import CredentialManager
 from .base_adapter import ValidationResult
 from .common_model import TimeSeries
@@ -91,10 +90,18 @@ class TimeSeriesManager:
     def _load_from_dataframes(
         self, dataframes: dict[str, pd.DataFrame], energy_system: esdl.EnergySystem
     ) -> tuple[dict[str, TimeSeries], ValidationResult]:
-        """Load time series from pandas DataFrames using pyESDL ProfileManager.
+        """Load time series from pandas DataFrames.
+
+        Each DataFrame column is stored as a separate TimeSeries under a
+        composite key (asset_id|column_name), matching the format used by
+        DatabaseTimeSeriesLoader so the ESDL adapter can resolve them.
 
         Args:
-            dataframes: Dict mapping asset IDs to pandas DataFrames
+            dataframes: Dict mapping asset IDs to pandas DataFrames with a
+                DatetimeIndex. All numeric columns are stored; columns whose
+                names are not recognised by the KPI calculators (e.g.
+                unknown_field, custom_metric) are stored but will not
+                contribute to any KPI — a warning is logged in that case.
             energy_system: ESDL energy system for validation
 
         Returns:
@@ -113,41 +120,55 @@ class TimeSeriesManager:
                     issues.append(f"Empty DataFrame for asset {asset_id}")
                     continue
 
-                # Use pyESDL ProfileManager for proper conversion
-                profile_manager = ProfileManager()
-
-                # Convert DataFrame to ProfileManager format
-                profile_header = ["datetime", "value"]  # pyESDL expects 'datetime' as first column
-                profile_data_list = [
-                    [timestamp.isoformat(), value]
-                    for timestamp, value in zip(
-                        df.index.tolist(), df.iloc[:, 0].tolist(), strict=True
-                    )
-                ]
-
-                # Set profile data using pyESDL ProfileManager
-                profile_manager.set_profile(
-                    profile_header=profile_header,
-                    profile_data_list=profile_data_list,
-                    profile_type=ProfileType.TIMESERIES,
-                )
-
-                # Detect time step from DataFrame index
+                # Detect time step from DataFrame index (same for all columns)
                 time_step = self._detect_time_step(df)
 
-                # Convert to internal TimeSeries format
-                # This maintains compatibility with existing KPI calculators
-                time_series_dict[asset_id] = TimeSeries(
-                    time_step=time_step,
-                    values=df.iloc[:, 0].tolist(),
-                )
+                # Process each column in the DataFrame
+                # Each column represents a different field (e.g., heat_supplied, power, flow)
+                for column_name in df.columns:
+                    try:
+                        if not pd.api.types.is_numeric_dtype(df[column_name]):
+                            error_msg = (
+                                f"Column '{column_name}' for asset {asset_id} has non-numeric "
+                                f"dtype '{df[column_name].dtype}' - skipping"
+                            )
+                            self.logger.warning(error_msg)
+                            issues.append(error_msg)
+                            continue
 
-                self.logger.debug(
-                    f"Converted DataFrame for asset {asset_id}: {len(df)} data points"
-                )
+                        # Create composite key: asset_id|field_name
+                        # This matches the format used by DatabaseTimeSeriesLoader
+                        composite_key = f"{asset_id}{COMPOSITE_KEY_SEPARATOR}{column_name}"
+
+                        # Convert to internal TimeSeries format
+                        # This maintains compatibility with existing KPI calculators
+                        time_series_dict[composite_key] = TimeSeries(
+                            time_step=time_step,
+                            values=df[column_name].tolist(),
+                        )
+
+                        if column_name not in KNOWN_TIME_SERIES_FIELDS:
+                            self.logger.warning(
+                                f"Column '{column_name}' for asset {asset_id} is not a "
+                                f"recognized KPI field and will not contribute to any KPI"
+                            )
+                        else:
+                            self.logger.debug(
+                                f"Converted DataFrame column '{column_name}' for asset "
+                                f"{asset_id}: {len(df)} data points"
+                            )
+
+                    except Exception as e:
+                        error_msg = (
+                            f"Failed to convert DataFrame column '{column_name}' "
+                            f"for asset {asset_id}: {e}"
+                        )
+                        self.logger.error(error_msg)
+                        issues.append(error_msg)
+                        continue
 
             except Exception as e:
-                error_msg = f"Failed to convert DataFrame for asset {asset_id}: {e}"
+                error_msg = f"Failed to process DataFrame for asset {asset_id}: {e}"
                 self.logger.error(error_msg)
                 issues.append(error_msg)
                 continue
@@ -207,15 +228,19 @@ class TimeSeriesManager:
                 issues.append(f"DataFrame for {asset_id} contains null values")
                 continue
 
-            # Check for reasonable data ranges
-            values = df.iloc[:, 0]
-            if (values < 0).any():
-                warnings.append(f"DataFrame for {asset_id} contains negative values")
-
-            if values.max() > 1e9:  # Very large values might indicate unit issues
-                warnings.append(
-                    f"DataFrame for {asset_id} contains very large values - check units"
-                )
+            # Check for reasonable data ranges across numeric columns only.
+            # Non-numeric columns are not range-checked here; they are rejected
+            # with an error in _load_from_dataframes during the conversion step.
+            for col, series in df.select_dtypes(include="number").items():
+                if (series < 0).any():
+                    warnings.append(
+                        f"DataFrame for {asset_id}, column '{col}' contains negative values"
+                    )
+                if series.max() > 1e9:  # Very large values might indicate unit issues
+                    warnings.append(
+                        f"DataFrame for {asset_id}, column '{col}' contains very large values"
+                        " - check units"
+                    )
 
         return ValidationResult(is_valid=len(issues) == 0, errors=issues, warnings=warnings)
 

--- a/src/kpicalculator/calculators/emission_calculator.py
+++ b/src/kpicalculator/calculators/emission_calculator.py
@@ -2,7 +2,14 @@
 # No typing imports needed currently
 
 from ..adapters.common_model import Asset, AssetType, EnergySystem
-from ..common.constants import KG_TO_TONS, SECONDS_PER_YEAR, TONS_TO_KG
+from ..common.constants import (
+    CONSUMPTION_FIELDS,
+    CONVERSION_FIELDS,
+    KG_TO_TONS,
+    PRODUCTION_FIELDS,
+    SECONDS_PER_YEAR,
+    TONS_TO_KG,
+)
 
 
 class EmissionCalculator:
@@ -101,13 +108,13 @@ class EmissionCalculator:
 
         # Select the correct time series key for the asset
         ts_options = {
-            AssetType.PRODUCER: ["ThermalProduction", "Production", "Energy"],
-            AssetType.GEOTHERMAL: ["ThermalProduction", "Production", "Energy"],
-            AssetType.CONSUMER: ["ThermalConsumption", "Consumption", "Energy"],
-            AssetType.CONVERSION: ["ElectricalConsumption", "ThermalProduction"],
+            AssetType.PRODUCER: PRODUCTION_FIELDS,
+            AssetType.GEOTHERMAL: PRODUCTION_FIELDS,
+            AssetType.CONSUMER: CONSUMPTION_FIELDS,
+            AssetType.CONVERSION: CONVERSION_FIELDS,
         }
         ts_name = None
-        options = ts_options.get(asset.asset_type, [])
+        options: tuple[str, ...] = ts_options.get(asset.asset_type, ())
         for key in options:
             if key in asset.time_series:
                 ts_name = key

--- a/src/kpicalculator/calculators/energy_calculator.py
+++ b/src/kpicalculator/calculators/energy_calculator.py
@@ -2,7 +2,12 @@
 # No typing imports needed currently
 
 from ..adapters.common_model import Asset, AssetType, EnergySystem
-from ..common.constants import SECONDS_PER_YEAR
+from ..common.constants import (
+    CONSUMPTION_FIELDS,
+    DEMAND_FIELDS,
+    PRODUCTION_FIELDS,
+    SECONDS_PER_YEAR,
+)
 
 
 class EnergyCalculator:
@@ -87,7 +92,7 @@ class EnergyCalculator:
 
         # Look for consumption time series
         ts_name = None
-        for name in ["ThermalConsumption", "Consumption", "Energy"]:
+        for name in CONSUMPTION_FIELDS:
             if name in asset.time_series:
                 ts_name = name
                 break
@@ -119,7 +124,7 @@ class EnergyCalculator:
 
         # Look for demand time series
         ts_name = None
-        for name in ["ThermalDemand", "Demand"]:
+        for name in DEMAND_FIELDS:
             if name in asset.time_series:
                 ts_name = name
                 break
@@ -151,7 +156,7 @@ class EnergyCalculator:
 
         # Look for production time series
         ts_name = None
-        for name in ["ThermalProduction", "Production", "Energy"]:
+        for name in PRODUCTION_FIELDS:
             if name in asset.time_series:
                 ts_name = name
                 break

--- a/src/kpicalculator/common/constants.py
+++ b/src/kpicalculator/common/constants.py
@@ -46,6 +46,22 @@ MINIMUM_PASSWORD_LENGTH = 8
 COMPOSITE_KEY_SEPARATOR = "|"
 COMPOSITE_KEY_FORMAT = "{asset_id}" + COMPOSITE_KEY_SEPARATOR + "{field_name}"
 
+# Field name lookup lists used by the KPI calculators.
+# Each tuple defines the priority order in which field names are tried for
+# a given energy category. The calculators import these directly so there
+# is a single source of truth.
+CONSUMPTION_FIELDS: tuple[str, ...] = ("ThermalConsumption", "Consumption", "Energy")
+DEMAND_FIELDS: tuple[str, ...] = ("ThermalDemand", "Demand")
+PRODUCTION_FIELDS: tuple[str, ...] = ("ThermalProduction", "Production", "Energy")
+ELECTRICAL_CONSUMPTION_FIELDS: tuple[str, ...] = ("ElectricalConsumption",)
+CONVERSION_FIELDS: tuple[str, ...] = ("ElectricalConsumption", "ThermalProduction")
+
+# Union of all recognised field names — used to warn when a DataFrame column
+# will not contribute to any KPI calculation.
+KNOWN_TIME_SERIES_FIELDS: frozenset[str] = frozenset(
+    CONSUMPTION_FIELDS + DEMAND_FIELDS + PRODUCTION_FIELDS + ELECTRICAL_CONSUMPTION_FIELDS
+)
+
 # Security-related ports to validate against
 DANGEROUS_PORTS = {22, 23, 80, 3389, 5985, 5986}  # SSH, Telnet, HTTP, RDP, WinRM
 # Secure database ports (allowed for SSL/TLS connections)

--- a/unit_test/test_examples.py
+++ b/unit_test/test_examples.py
@@ -67,26 +67,28 @@ class TestReadmeExamples:
 
         assert "costs" in results
 
-    def test_timeseries_dataframes_accepted_without_error(self) -> None:
-        """Test that the timeseries_dataframes parameter is accepted without error.
+    def test_timeseries_dataframes_produce_valid_kpi_results(self) -> None:
+        """Test that the timeseries_dataframes parameter works with composite keys.
 
-        NOTE: DataFrame time series currently do not reach KPI calculators because
-        _load_from_dataframes stores entries under plain asset ID keys, while the
-        adapter expects composite keys (asset_id|field_name). This is a known
-        limitation — see architecture.rst and ROADMAP.md for details.
-
-        This test verifies that the API accepts DataFrames without crashing and
-        returns a well-formed result structure. When the mapping is fixed, this
-        test should be updated to assert non-zero energy values.
+        This test verifies that DataFrame time series are properly mapped using
+        composite keys (asset_id|field_name) and reaches the KPI calculators.
         """
         esdl_file = "unit_test/data/Unit_test_ESDL.esdl"
 
         timesteps = 24
         datetime_index = pd.date_range("2019-01-01T00:00:00", periods=timesteps, freq="h")
 
+        # Use actual asset ID from the ESDL file
+        # GenericConsumer with id="a5243809-0077-46e5-a0ea-09aa486f5e96"
+        asset_id = "a5243809-0077-46e5-a0ea-09aa486f5e96"
+
         timeseries_dataframes = {
-            "placeholder_asset": pd.DataFrame(
-                {"heat_supplied": [100000.0 + i * 2000 for i in range(timesteps)]},
+            asset_id: pd.DataFrame(
+                {
+                    # Column names must match the field names expected by the energy
+                    # calculator: ThermalConsumption, Consumption, ThermalProduction, etc.
+                    "ThermalConsumption": [100000.0 + i * 2000 for i in range(timesteps)],
+                },
                 index=datetime_index,
             ),
         }
@@ -96,9 +98,9 @@ class TestReadmeExamples:
         assert "costs" in results
         assert "energy" in results
         assert "emissions" in results
-
-        # TODO(#30): When DataFrame key mapping is fixed, assert non-zero energy
-        # values here using real asset IDs from the ESDL fixture.
+        assert results["energy"]["consumption"] > 0, (
+            "DataFrame data must reach the energy calculator via composite keys"
+        )
 
     def test_advanced_batch_processing(self) -> None:
         """Test Advanced Batch Processing example."""

--- a/unit_test/test_kpi_calculator.py
+++ b/unit_test/test_kpi_calculator.py
@@ -1,6 +1,9 @@
+import math
 import sys
 import unittest
 from pathlib import Path
+
+import pandas as pd
 
 # Get the absolute path to the test directory
 TEST_DIR = Path(__file__).parent
@@ -142,6 +145,119 @@ class EsdlStringLoadingTest(unittest.TestCase):
             places=6,
             msg="Emissions mismatch between file and string loading",
         )
+
+
+class DataFrameTimeSeriesTest(unittest.TestCase):
+    """Test DataFrame time series loading via timeseries_dataframes parameter."""
+
+    TIMESTEPS = 24
+
+    def setUp(self) -> None:
+        self.esdl_file = str(DATA_DIR / "Unit_test_ESDL.esdl")
+        # Asset ID from the test ESDL fixture (GenericConsumer)
+        self.asset_id = "a5243809-0077-46e5-a0ea-09aa486f5e96"
+
+    def _make_dataframe(self, columns: dict) -> pd.DataFrame:
+        index = pd.date_range("2019-01-01T00:00:00", periods=self.TIMESTEPS, freq="h")
+        return pd.DataFrame(columns, index=index)
+
+    def test_dataframe_composite_keys_reach_energy_calculator(self) -> None:
+        """Test that DataFrame columns are mapped to composite keys and reach the calculator."""
+        from kpicalculator.common.constants import SECONDS_PER_YEAR
+
+        power_w = 100_000.0
+        time_step_s = 3600.0
+        # Annual energy = sum(values) * time_step * (SECONDS_PER_YEAR / total_duration)
+        expected_j = (
+            power_w
+            * self.TIMESTEPS
+            * time_step_s
+            * (SECONDS_PER_YEAR / (time_step_s * self.TIMESTEPS))
+        )
+
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(
+            self.esdl_file,
+            timeseries_dataframes={
+                self.asset_id: self._make_dataframe(
+                    {"ThermalConsumption": [power_w] * self.TIMESTEPS}
+                )
+            },
+        )
+        results = kpi_manager.calculate_all_kpis()
+
+        self.assertTrue(
+            math.isclose(results["energy"]["consumption"], expected_j, rel_tol=1e-9),
+            msg=f"Expected {expected_j} J, got {results['energy']['consumption']} J",
+        )
+
+    def test_multiple_dataframe_columns_produce_independent_time_series(self) -> None:
+        """Test that each DataFrame column becomes a separate composite-keyed time series."""
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(
+            self.esdl_file,
+            timeseries_dataframes={
+                self.asset_id: self._make_dataframe(
+                    {
+                        "ThermalConsumption": [100_000.0] * self.TIMESTEPS,
+                        "ThermalDemand": [80_000.0] * self.TIMESTEPS,
+                    }
+                )
+            },
+        )
+        asset = next(a for a in kpi_manager.energy_system.assets if a.id == self.asset_id)
+        self.assertIn("ThermalConsumption", asset.time_series)
+        self.assertIn("ThermalDemand", asset.time_series)
+        self.assertEqual(
+            asset.time_series["ThermalConsumption"].values, [100_000.0] * self.TIMESTEPS
+        )
+        self.assertEqual(asset.time_series["ThermalDemand"].values, [80_000.0] * self.TIMESTEPS)
+
+    def test_unknown_column_name_does_not_crash(self) -> None:
+        """Test that unrecognised column names are stored but don't crash the calculator."""
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(
+            self.esdl_file,
+            timeseries_dataframes={
+                self.asset_id: self._make_dataframe({"unknown_field": [1.0] * self.TIMESTEPS})
+            },
+        )
+        results = kpi_manager.calculate_all_kpis()
+        self.assertEqual(
+            results["energy"]["consumption"],
+            0.0,
+            msg="Unrecognised column names must not contribute to energy consumption",
+        )
+
+    def test_non_numeric_column_is_skipped(self) -> None:
+        """Test that non-numeric DataFrame columns are skipped with a validation issue."""
+        from esdl.esdl_handler import EnergySystemHandler
+
+        from kpicalculator.adapters.time_series_manager import TimeSeriesManager
+        from kpicalculator.common.constants import COMPOSITE_KEY_SEPARATOR
+
+        handler = EnergySystemHandler()
+        energy_system = handler.load_file(self.esdl_file)
+
+        df = self._make_dataframe({"ThermalConsumption": ["a", "b"] * (self.TIMESTEPS // 2)})
+        expected_dtype = df["ThermalConsumption"].dtype
+        expected_error = (
+            f"Column 'ThermalConsumption' for asset {self.asset_id} has non-numeric "
+            f"dtype '{expected_dtype}' - skipping"
+        )
+
+        manager = TimeSeriesManager()
+        time_series_dict, validation = manager.load_time_series(
+            energy_system, timeseries_dataframes={self.asset_id: df}
+        )
+
+        self.assertFalse(
+            any(
+                k.endswith(f"{COMPOSITE_KEY_SEPARATOR}ThermalConsumption") for k in time_series_dict
+            ),
+            "Non-numeric column must not be stored as a TimeSeries",
+        )
+        self.assertIn(expected_error, validation.errors)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

Changes:
  - `_load_from_dataframes` now iterates over DataFrame columns and creates
    composite keys per column, matching the format used by DatabaseTimeSeriesLoader
  - Remove ProfileManager usage (not needed, caused errors)
  - Validate per-column numeric dtype; skip non-numeric columns with a clear
    error recorded in ValidationResult
  - Range checks in _validate_dataframe_time_series now use select_dtypes
    instead of a redundant is_numeric_dtype guard
  - Extract time series field name lists into constants (CONSUMPTION_FIELDS,
    DEMAND_FIELDS, PRODUCTION_FIELDS, CONVERSION_FIELDS) as single source of
    truth; calculators import from constants, KNOWN_TIME_SERIES_FIELDS derived
    from them — no more duplicated inline literals
  - Warn when a DataFrame column name is not in KNOWN_TIME_SERIES_FIELDS so
    callers are alerted that the column will not contribute to any KPI
  - Add DataFrameTimeSeriesTest to test_kpi_calculator.py covering composite
    key mapping, multiple columns, unrecognised field names, and non-numeric
    column rejection (exact error message asserted)
  - Update test fixture to use real asset ID and ThermalConsumption field name
  - Use math.isclose (rel_tol=1e-9) for Joule-scale float comparison