### PR TITLE
deps: Bumps wheel version for security update

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ docs = [
 build = [
     "setuptools >= 70.0.0",
     "pip >= 25.3",
-    "wheel >= 0.46.2",
+    "wheel ~= 0.46.2",
     "setuptools-git-versioning < 2",
     "build ~= 1.0.3",
     "bump2version==1.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ kpicalculator = "kpicalculator:main"
 build-backend = "setuptools.build_meta"
 requires = [
     "setuptools >= 70.0.0",  # Security: CVE fixes in 70.0.0+
-    "wheel >= 0.46.2",
+    "wheel ~= 0.46.2",
     "setuptools-git-versioning<2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ docs = [
 build = [
     "setuptools >= 70.0.0",
     "pip >= 25.3",
-    "wheel ~= 0.40.0",
+    "wheel >= 0.46.2",
     "setuptools-git-versioning < 2",
     "build ~= 1.0.3",
     "bump2version==1.0.1",
@@ -93,7 +93,7 @@ kpicalculator = "kpicalculator:main"
 build-backend = "setuptools.build_meta"
 requires = [
     "setuptools >= 70.0.0",  # Security: CVE fixes in 70.0.0+
-    "wheel ~= 0.40.0",
+    "wheel >= 0.46.2",
     "setuptools-git-versioning<2",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ build = [
     { name = "pip", specifier = ">=25.3" },
     { name = "setuptools", specifier = ">=70.0.0" },
     { name = "setuptools-git-versioning", specifier = "<2" },
-    { name = "wheel", specifier = "~=0.40.0" },
+    { name = "wheel", specifier = ">=0.46.2" },
 ]
 dev = [
     { name = "bandit", specifier = ">=1.7.0" },
@@ -624,7 +624,7 @@ dev = [
     { name = "sphinx-autodoc-typehints", specifier = ">=1.18.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.0" },
     { name = "vulture", specifier = ">=2.0.0" },
-    { name = "wheel", specifier = "~=0.40.0" },
+    { name = "wheel", specifier = ">=0.46.2" },
 ]
 docs = [
     { name = "furo", specifier = ">=2023.1.0" },
@@ -1860,11 +1860,14 @@ wheels = [
 
 [[package]]
 name = "wheel"
-version = "0.40.0"
+version = "0.46.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/ef/0335f7217dd1e8096a9e8383e1d472aa14717878ffe07c4772e68b6e8735/wheel-0.40.0.tar.gz", hash = "sha256:cd1196f3faee2b31968d626e1731c94f99cbdb67cf5a46e4f5656cbee7738873", size = 96226, upload-time = "2023-03-14T15:10:02.873Z" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/24/a2eb353a6edac9a0303977c4cb048134959dd2a51b48a269dfc9dde00c8a/wheel-0.46.3.tar.gz", hash = "sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803", size = 60605, upload-time = "2026-01-22T12:39:49.136Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/86/cc8d1ff2ca31a312a25a708c891cf9facbad4eae493b3872638db6785eb5/wheel-0.40.0-py3-none-any.whl", hash = "sha256:d236b20e7cb522daf2390fa84c55eea81c5c30190f90f29ae2ca1ad8355bf247", size = 64545, upload-time = "2023-03-14T15:10:00.828Z" },
+    { url = "https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl", hash = "sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d", size = 30557, upload-time = "2026-01-22T12:39:48.099Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps wheel version from 0.40.0 to 0.46.2 to resolve a high severity Dependabot Alert on wheel:
https://github.com/Project-OMOTES/kpi-calculator/security/dependabot/3