### PR TITLE
fix sidebar navigation with container pages for proper hierarchy

### DIFF
--- a/doc/developer_guide.rst
+++ b/doc/developer_guide.rst
@@ -1,0 +1,8 @@
+Developer Guide
+===============
+
+.. toctree::
+   :maxdepth: 1
+
+   dev_documentation/architecture
+   dev_documentation/development

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -34,24 +34,6 @@ usage examples, and results format.
    :hidden:
 
    getting_started
-
-.. toctree::
-   :hidden:
-   :caption: User Guide
-
-   user_documentation/kpi_guide
-   user_documentation/kpi_reference
-
-.. toctree::
-   :hidden:
-   :caption: Developer Guide
-
-   dev_documentation/architecture
-   dev_documentation/development
-
-.. toctree::
-   :hidden:
-   :caption: Reference
-
-   api_reference
-   indices
+   user_guide
+   developer_guide
+   reference

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -1,0 +1,8 @@
+Reference
+=========
+
+.. toctree::
+   :maxdepth: 2
+
+   api_reference
+   indices

--- a/doc/user_guide.rst
+++ b/doc/user_guide.rst
@@ -1,0 +1,8 @@
+User Guide
+==========
+
+.. toctree::
+   :maxdepth: 1
+
+   user_documentation/kpi_guide
+   user_documentation/kpi_reference


### PR DESCRIPTION
 Adds container pages (user_guide.rst, developer_guide.rst, reference.rst) with toctrees to maintain proper sidebar nesting. Each container page lists its child documents for navigation.