### PR TITLE
fix: warn on unsupported cost units and resolve pre-commit violations

### DIFF
--- a/run.py
+++ b/run.py
@@ -24,19 +24,20 @@ COMMANDS = {
 
 def main() -> int:
     if len(sys.argv) < 2 or sys.argv[1] not in (*COMMANDS, "check"):
-        print("Usage: uv run run.py {lint|format|check|test|pre-commit}")
+        if __doc__:
+            sys.stderr.write(__doc__)
         return 1
 
     task = sys.argv[1]
 
     if task == "check":
         for name in ("lint", "format", "mypy"):
-            rc = subprocess.call(COMMANDS[name])
+            rc = subprocess.run(COMMANDS[name], check=False).returncode  # noqa: S603 - literal command arrays, no user input
             if rc != 0:
                 return rc
         return 0
 
-    return subprocess.call(COMMANDS[task])
+    return subprocess.run(COMMANDS[task], check=False).returncode  # noqa: S603 - literal command arrays, no user input
 
 
 if __name__ == "__main__":

--- a/src/kpicalculator/calculators/cost_calculator.py
+++ b/src/kpicalculator/calculators/cost_calculator.py
@@ -1,4 +1,5 @@
 # src/kpicalculator/calculators/cost_calculator.py
+import logging
 import math
 
 from ..adapters.common_model import Asset, AssetType, EnergySystem
@@ -7,6 +8,8 @@ from ..common.constants import (
     PERCENTAGE_TO_DECIMAL,
     SECONDS_PER_YEAR,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class CostCalculator:
@@ -198,6 +201,11 @@ class CostCalculator:
         allowed_units = ["EUR", "EUR/kW", "EUR/MW", "EUR/m", "EUR/km", "EUR/m3"]
 
         if asset.investment_cost_unit not in allowed_units:
+            logger.warning(
+                "Unsupported unit '%s' for investment cost on asset '%s'. Cost ignored.",
+                asset.investment_cost_unit,
+                asset.name,
+            )
             return 0.0
 
         value = asset.investment_cost
@@ -231,6 +239,11 @@ class CostCalculator:
         allowed_units = ["EUR", "EUR/kW", "EUR/MW", "EUR/m", "EUR/km", "EUR/m3"]
 
         if asset.installation_cost_unit not in allowed_units:
+            logger.warning(
+                "Unsupported unit '%s' for installation cost on asset '%s'. Cost ignored.",
+                asset.installation_cost_unit,
+                asset.name,
+            )
             return 0.0
 
         value = asset.installation_cost
@@ -264,6 +277,11 @@ class CostCalculator:
         allowed_units = ["EUR", "EUR/yr", "% OF CAPEX", "EUR/MW"]
 
         if asset.fixed_operational_cost_unit not in allowed_units:
+            logger.warning(
+                "Unsupported unit '%s' for fixed operational cost on asset '%s'. Cost ignored.",
+                asset.fixed_operational_cost_unit,
+                asset.name,
+            )
             return 0.0
 
         value = asset.fixed_operational_cost
@@ -296,6 +314,11 @@ class CostCalculator:
         allowed_units = ["EUR", "EUR/yr", "EUR/kWh", "EUR/MWh"]
 
         if asset.variable_operational_cost_unit not in allowed_units:
+            logger.warning(
+                "Unsupported unit '%s' for variable operational cost on asset '%s'. Cost ignored.",
+                asset.variable_operational_cost_unit,
+                asset.name,
+            )
             return 0.0
 
         value = asset.variable_operational_cost
@@ -341,6 +364,11 @@ class CostCalculator:
         allowed_units = ["EUR", "EUR/yr", "% OF CAPEX", "EUR/MW"]
 
         if asset.fixed_maintenance_cost_unit not in allowed_units:
+            logger.warning(
+                "Unsupported unit '%s' for fixed maintenance cost on asset '%s'. Cost ignored.",
+                asset.fixed_maintenance_cost_unit,
+                asset.name,
+            )
             return 0.0
 
         value = asset.fixed_maintenance_cost
@@ -373,6 +401,11 @@ class CostCalculator:
         allowed_units = ["EUR", "EUR/yr", "EUR/kWh", "EUR/MWh"]
 
         if asset.variable_maintenance_cost_unit not in allowed_units:
+            logger.warning(
+                "Unsupported unit '%s' for variable maintenance cost on asset '%s'. Cost ignored.",
+                asset.variable_maintenance_cost_unit,
+                asset.name,
+            )
             return 0.0
 
         value = asset.variable_maintenance_cost

--- a/unit_test/test_kpi_calculator.py
+++ b/unit_test/test_kpi_calculator.py
@@ -1166,6 +1166,74 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
 
         self.assertEqual(calc._calculate_variable_maintenance_cost(asset), 0.0)
 
+    def _assert_unsupported_unit_logs_warning(
+        self, method_name: str, unit_field: str, unit_value: str, cost_field: str
+    ) -> None:
+        """Helper: verify that an unsupported unit logs a warning and returns 0.0."""
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        asset = self._make_asset(**{cost_field: 5.0, unit_field: unit_value})
+        calc = CostCalculator(self._make_system(asset))
+
+        with self.assertLogs("kpicalculator.calculators.cost_calculator", level="WARNING") as cm:
+            result = getattr(calc, method_name)(asset)
+
+        self.assertEqual(result, 0.0)
+        self.assertEqual(len(cm.output), 1)
+        self.assertIn("Unsupported unit", cm.output[0])
+        self.assertIn(unit_value, cm.output[0])
+
+    def test_unsupported_investment_cost_unit_logs_warning(self) -> None:
+        """'% OF CAPEX' is valid for fixed ops/maintenance but not investment cost."""
+        self._assert_unsupported_unit_logs_warning(
+            "_calculate_investment_cost", "investment_cost_unit", "% OF CAPEX", "investment_cost"
+        )
+
+    def test_unsupported_installation_cost_unit_logs_warning(self) -> None:
+        """'% OF CAPEX' is valid for fixed ops/maintenance but not installation cost."""
+        self._assert_unsupported_unit_logs_warning(
+            "_calculate_installation_cost",
+            "installation_cost_unit",
+            "% OF CAPEX",
+            "installation_cost",
+        )
+
+    def test_unsupported_fixed_operational_cost_unit_logs_warning(self) -> None:
+        """'EUR/km' is valid for investment/installation but not fixed operational cost."""
+        self._assert_unsupported_unit_logs_warning(
+            "_calculate_fixed_operational_cost",
+            "fixed_operational_cost_unit",
+            "EUR/km",
+            "fixed_operational_cost",
+        )
+
+    def test_unsupported_variable_operational_cost_unit_logs_warning(self) -> None:
+        """'% OF CAPEX' is valid for fixed ops/maintenance but not variable operational cost."""
+        self._assert_unsupported_unit_logs_warning(
+            "_calculate_variable_operational_cost",
+            "variable_operational_cost_unit",
+            "% OF CAPEX",
+            "variable_operational_cost",
+        )
+
+    def test_unsupported_fixed_maintenance_cost_unit_logs_warning(self) -> None:
+        """'EUR/km' is valid for investment/installation but not fixed maintenance cost."""
+        self._assert_unsupported_unit_logs_warning(
+            "_calculate_fixed_maintenance_cost",
+            "fixed_maintenance_cost_unit",
+            "EUR/km",
+            "fixed_maintenance_cost",
+        )
+
+    def test_unsupported_variable_maintenance_cost_unit_logs_warning(self) -> None:
+        """'% OF CAPEX' is valid for fixed ops/maintenance but not variable maintenance cost."""
+        self._assert_unsupported_unit_logs_warning(
+            "_calculate_variable_maintenance_cost",
+            "variable_maintenance_cost_unit",
+            "% OF CAPEX",
+            "variable_maintenance_cost",
+        )
+
 
 class BaseAdapterValidationTest(unittest.TestCase):
     """Tests for BaseAdapter._validate_energy_system().

--- a/uv.lock
+++ b/uv.lock
@@ -599,7 +599,7 @@ build = [
     { name = "pip", specifier = ">=25.3" },
     { name = "setuptools", specifier = ">=70.0.0" },
     { name = "setuptools-git-versioning", specifier = "<2" },
-    { name = "wheel", specifier = ">=0.46.2" },
+    { name = "wheel", specifier = "~=0.46.2" },
 ]
 dev = [
     { name = "bandit", specifier = ">=1.7.0" },
@@ -624,7 +624,7 @@ dev = [
     { name = "sphinx-autodoc-typehints", specifier = ">=1.18.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.0" },
     { name = "vulture", specifier = ">=2.0.0" },
-    { name = "wheel", specifier = ">=0.46.2" },
+    { name = "wheel", specifier = "~=0.46.2" },
 ]
 docs = [
     { name = "furo", specifier = ">=2023.1.0" },


### PR DESCRIPTION

  ## Summary
  - Log warning when cost calculator encounters unsupported unit strings instead of silently returning 0.0 (prevents silent data loss)
  - Fix ruff T201/S603 violations in run.py
  - Update uv.lock to match pyproject.toml wheel specifier