### PR TITLE
adapters: add SimulatorAdapter and EsdlAdapter.load_from_edl_objects

### DIFF
--- a/doc/dev_documentation/architecture.rst
+++ b/doc/dev_documentation/architecture.rst
@@ -36,7 +36,7 @@ The package has four layers:
    │    cost_calculator    energy_calculator    emission_calc  │
    ├──────────────────────────────────────────────────────────┤
    │  Adapters                                                │
-   │    esdl_adapter    time_series_manager    database_loader │
+   │    esdl_adapter    simulator_adapter    time_series_mgr   │
    ├──────────────────────────────────────────────────────────┤
    │  Common Model                                            │
    │    Asset    TimeSeries    EnergySystem                    │
@@ -328,9 +328,10 @@ Project Layout
    ├── kpi_manager.py                  # Orchestrator + result TypedDicts
    ├── exceptions.py                   # Custom exception hierarchy
    ├── adapters/
-   │   ├── base_adapter.py             # Abstract base + protocols
+   │   ├── base_adapter.py             # Abstract base (enforces EnergySystem return)
    │   ├── common_model.py             # Asset, TimeSeries, EnergySystem
    │   ├── esdl_adapter.py             # ESDL parsing + cost extraction
+   │   ├── simulator_adapter.py        # OMOTES Simulator port→asset mapping
    │   ├── time_series_manager.py      # Multi-source time series loading
    │   ├── database_time_series_loader.py  # InfluxDB integration
    │   └── xml_time_series_adapter.py  # XML time series (testing)
@@ -391,11 +392,25 @@ Adding a New Adapter
 
 To add a new data source (e.g., MESIDO optimization results):
 
-1. Create ``adapters/mesido_adapter.py``
-2. Parse the source data and construct ``Asset`` objects with the properties your source provides (costs, time series, physical properties)
-3. Return a populated ``EnergySystem``
-4. Add a ``load_from_mesido()`` method to ``KpiManager``
+1. Create ``adapters/mesido_adapter.py`` subclassing ``BaseAdapter``
+2. Define a **typed** ``load_data()`` method whose signature matches the actual inputs
+   of your data source — do not try to fit all adapters into one shared signature
+3. Parse the source data and construct ``Asset`` objects with costs, time series, and
+   physical properties; return a populated ``EnergySystem``
+4. Add a ``load_from_mesido()`` method to ``KpiManager`` that instantiates your adapter
+   and calls it directly
+5. Export the new class from ``adapters/__init__.py``
 
 The calculators don't need to change — they only depend on the common model.
 
-The ``base_adapter.py`` file defines protocols for ``MesidoResultsProtocol`` and ``SimulatorResultsProtocol`` as a starting point, though the actual interface can be adjusted to match what the source system provides.
+**BaseAdapter design principle**: the base class enforces only the ``EnergySystem``
+return type. Each adapter owns its own loading signature. ``KpiManager`` calls the
+specific adapter it knows about directly, not through the base class interface. The
+``SimulatorAdapter`` (``adapters/simulator_adapter.py``) is the reference implementation
+for this pattern: it accepts a ``(pd.DataFrame, esdl_string)`` pair, resolves port IDs
+to asset IDs, and delegates cost extraction to ``EsdlAdapter.load_from_string()``.
+
+The ``# type: ignore[override]`` annotations on ``load_data`` and ``validate_source``
+in concrete adapters are intentional — they narrow the inherited ``Any`` signature to
+specific types without breaking Liskov substitutability in practice, because callers
+always use the concrete type directly.

--- a/src/kpicalculator/adapters/__init__.py
+++ b/src/kpicalculator/adapters/__init__.py
@@ -6,6 +6,7 @@ from .base_adapter import BaseAdapter, ValidationResult
 from .common_model import Asset, AssetType, EnergySystem, TimeSeries
 from .database_time_series_loader import DatabaseTimeSeriesLoader
 from .esdl_adapter import EsdlAdapter
+from .simulator_adapter import SimulatorAdapter
 from .time_series_manager import TimeSeriesManager
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     "DatabaseTimeSeriesLoader",
     "DatabaseCredentials",
     "EsdlAdapter",
+    "SimulatorAdapter",
     "TimeSeriesManager",
     "Asset",
     "AssetType",

--- a/src/kpicalculator/adapters/base_adapter.py
+++ b/src/kpicalculator/adapters/base_adapter.py
@@ -2,43 +2,10 @@
 """Base adapter interface for consistent data source integration."""
 
 from abc import ABC, abstractmethod
-from pathlib import Path
-from typing import Protocol
-
-import pandas as pd  # type: ignore[import-untyped]
+from typing import Any
 
 from ..common.constants import COST_UNIT_FACTORS
 from .common_model import EnergySystem
-
-
-class DatabaseReference(Protocol):
-    """Protocol for database connection references."""
-
-    host: str
-    port: int
-    database: str
-    username: str | None
-    password: str | None
-
-
-class MesidoResultsProtocol(Protocol):
-    """Protocol for MESIDO optimization results."""
-
-    assets: dict[str, object]
-    time_series: dict[str, object]
-    parameters: dict[str, float]
-    # Optional database reference for time series
-    database_ref: DatabaseReference | None
-
-
-class SimulatorResultsProtocol(Protocol):
-    """Protocol for OMOTES Simulator results."""
-
-    assets: dict[str, object]
-    simulation_data: dict[str, object]
-    time_series: dict[str, object]
-    # Optional database reference for time series
-    database_ref: DatabaseReference | None
 
 
 class ValidationResult:
@@ -58,8 +25,17 @@ class ValidationResult:
 class BaseAdapter(ABC):
     """Abstract base class for all data source adapters.
 
-    This interface ensures consistency across ESDL, MESIDO, and Simulator adapters.
-    All adapters must implement these methods for standardized data loading.
+    The base class enforces only the ``EnergySystem`` return type. Each concrete
+    adapter defines its own typed ``load_data()`` signature matching the inputs
+    that its data source actually requires. Callers (e.g. ``KpiManager``) invoke
+    the specific adapter directly rather than through this base interface, so
+    there is no need to funnel every adapter's parameters through a single
+    overly-broad signature.
+
+    All adapters must implement:
+        - ``load_data()`` — typed per adapter, returns ``EnergySystem``
+        - ``validate_source()`` — returns ``ValidationResult``
+        - ``get_supported_source_type()`` — returns a short string identifier
     """
 
     def __init__(self) -> None:
@@ -67,89 +43,72 @@ class BaseAdapter(ABC):
         self.unit_conversions: dict[str, float] = dict(COST_UNIT_FACTORS)
 
     @abstractmethod
-    def load_data(
-        self,
-        source: str | Path | MesidoResultsProtocol | SimulatorResultsProtocol,
-        time_series_file: str | None = None,
-        timeseries_dataframes: dict[str, pd.DataFrame] | None = None,
-        use_database_profiles: bool = True,
-    ) -> EnergySystem:
-        """Load data from source and convert to common model.
+    def load_data(self, source: Any, **kwargs: Any) -> EnergySystem:
+        """Load data from source and convert to the common model.
 
-        Args:
-            source: Data source - can be:
-                - str/Path: ESDL file path (may contain InfluxDB profile references)
-                - MesidoResultsProtocol: MESIDO optimization results (data structures or DB refs)
-                - SimulatorResultsProtocol: OMOTES Simulator results (data structures or DB refs)
-            time_series_file: Optional XML time series file path (testing only)
-            timeseries_dataframes: Optional dict mapping asset IDs to pandas DataFrames
-                with time-indexed energy/power data. When provided, takes precedence
-                over database loading and time_series_file parameter.
-            use_database_profiles: Whether to load database-referenced time series
+        Concrete adapters narrow ``source: Any`` to their actual input type.
+        Always call through the concrete adapter type — never through a
+        ``BaseAdapter`` reference — or the narrowed signature will not apply.
 
         Returns:
-            EnergySystem object with standardized data model
+            EnergySystem object with standardised data model.
 
         Raises:
-            ValidationError: If source data is invalid
-            DataSourceError: If data loading fails
+            ValidationError: If source data is invalid.
+            DataSourceError: If data loading fails.
         """
-        pass
 
     @abstractmethod
-    def validate_source(
-        self, source: str | Path | MesidoResultsProtocol | SimulatorResultsProtocol
-    ) -> ValidationResult:
+    def validate_source(self, source: Any) -> ValidationResult:
         """Validate that source data is compatible with this adapter.
 
         Args:
-            source: Data source to validate
+            source: Data source to validate.
 
         Returns:
-            ValidationResult indicating if source is valid
+            ValidationResult indicating if source is valid.
         """
-        pass
 
     @abstractmethod
     def get_supported_source_type(self) -> str:
-        """Return identifier for this adapter's source type.
+        """Return a short identifier for this adapter's source type.
 
         Returns:
-            String identifier (e.g., "esdl", "mesido", "simulator")
+            String identifier, e.g. ``"esdl"``, ``"mesido"``, ``"simulator"``.
         """
-        pass
 
     def get_supported_parameters(self) -> list[str]:
-        """Return list of supported optional parameters for load_data.
+        """Return optional parameter names accepted by ``load_data``.
 
         Returns:
-            List of parameter names this adapter supports
+            List of parameter names this adapter supports beyond ``source``.
         """
         return []
 
     def _validate_energy_system(self, energy_system: EnergySystem) -> ValidationResult:
         """Validate the constructed energy system for consistency.
 
+        Intended to be called by concrete ``load_data`` implementations after
+        the ``EnergySystem`` has been built, so that warnings about empty
+        systems or invalid asset properties are surfaced uniformly.
+
         Args:
-            energy_system: The constructed EnergySystem object
+            energy_system: The constructed EnergySystem object.
 
         Returns:
-            ValidationResult with validation status and messages
+            ValidationResult with validation status and messages.
         """
         errors = []
         warnings = []
 
-        # Check for empty system
         if not energy_system.assets:
             warnings.append("Energy system contains no assets")
 
-        # Validate asset properties
         for asset in energy_system.assets:
             if asset.technical_lifetime <= 0:
                 errors.append(
                     f"Asset {asset.id} has invalid technical lifetime: {asset.technical_lifetime}"
                 )
-
             if asset.power < 0:
                 errors.append(f"Asset {asset.id} has negative power: {asset.power}")
 

--- a/src/kpicalculator/adapters/esdl_adapter.py
+++ b/src/kpicalculator/adapters/esdl_adapter.py
@@ -18,12 +18,7 @@ from ..common.constants import (
 from ..exceptions import SecurityError, ValidationError
 from ..security.credential_manager import CredentialManager
 from ..security.input_validator import InputValidator
-from .base_adapter import (
-    BaseAdapter,
-    MesidoResultsProtocol,
-    SimulatorResultsProtocol,
-    ValidationResult,
-)
+from .base_adapter import BaseAdapter, ValidationResult
 from .common_model import Asset, AssetType, EnergySystem, TimeSeries
 from .database_time_series_loader import DatabaseTimeSeriesLoader
 from .time_series_manager import TimeSeriesManager
@@ -54,33 +49,33 @@ class EsdlAdapter(BaseAdapter):
         self.time_series_manager = TimeSeriesManager(credential_manager)
         self.logger = logging.getLogger(__name__)
 
-    def load_data(
+    def load_data(  # type: ignore[override]  # narrows source: Any → str | Path intentionally
         self,
-        source: str | Path | MesidoResultsProtocol | SimulatorResultsProtocol,
+        source: str | Path,
         time_series_file: str | None = None,
         timeseries_dataframes: dict[str, pd.DataFrame] | None = None,
         use_database_profiles: bool = True,
     ) -> EnergySystem:
-        """Load energy system data from ESDL file.
+        """Load energy system data from an ESDL file.
 
         Costs are extracted from ESDL costInformation elements.
 
         Args:
-            source: ESDL file path (only str/Path supported by this adapter)
-            time_series_file: Optional XML time series file path (testing only)
+            source: Path to the ESDL file (str or Path).
+            time_series_file: Optional XML time series file path (testing only).
             timeseries_dataframes: Optional dict mapping asset IDs to pandas DataFrames
                 with time-indexed energy/power data. When provided, takes precedence
-                over database loading and time_series_file parameter.
-            use_database_profiles: Whether to load InfluxDB profiles
+                over database loading and time_series_file.
+            use_database_profiles: Whether to load InfluxDB profiles.
 
         Returns:
-            EnergySystem object with costs from ESDL costInformation
+            EnergySystem object with costs from ESDL costInformation.
 
         Raises:
-            TypeError: If source is not a file path (MESIDO/Simulator not supported)
+            TypeError: If source is not a str or Path.
         """
-        if not isinstance(source, str | Path):
-            raise TypeError(f"ESDL adapter only supports file paths, got {type(source)}")
+        if not isinstance(source, (str, Path)):
+            raise TypeError(f"EsdlAdapter only supports file paths, got {type(source).__name__}")
 
         esdl_file = str(source)
 
@@ -168,6 +163,40 @@ class EsdlAdapter(BaseAdapter):
             es=es,
             model_name=model_name,
             source_metadata={"esdl_source": "string"},
+            time_series_file=None,
+            timeseries_dataframes=timeseries_dataframes,
+            use_database_profiles=use_database_profiles,
+        )
+
+    def load_from_esdl_object(
+        self,
+        es: esdl.EnergySystem,
+        timeseries_dataframes: dict[str, pd.DataFrame] | None = None,
+        use_database_profiles: bool = False,
+    ) -> EnergySystem:
+        """Load from an already-parsed PyESDL EnergySystem object.
+
+        Prefer this over ``load_from_string()`` when the caller has already parsed
+        the ESDL XML — for example, when the object must be inspected before loading
+        (e.g. port→asset resolution in ``SimulatorAdapter``).  Use
+        ``load_from_string()`` when only the raw XML string is available.
+
+        Avoids a second ``EnergySystemHandler.load_from_string()`` call when the
+        caller has already parsed the ESDL (e.g. ``SimulatorAdapter``).
+
+        Args:
+            es: Parsed PyESDL EnergySystem.
+            timeseries_dataframes: Optional asset-id-keyed DataFrames.
+            use_database_profiles: Whether to load InfluxDB profiles.
+
+        Returns:
+            EnergySystem with costs extracted from the ESDL object.
+        """
+        model_name = es.name if es.name else "esdl_from_object"
+        return self._process_energy_system(
+            es=es,
+            model_name=model_name,
+            source_metadata={"esdl_source": "object"},
             time_series_file=None,
             timeseries_dataframes=timeseries_dataframes,
             use_database_profiles=use_database_profiles,
@@ -262,15 +291,26 @@ class EsdlAdapter(BaseAdapter):
         # Log summary of any session warnings to provide final context
         self._log_session_summary()
 
+        # Warnings (e.g. empty system) are non-fatal; errors (e.g. negative power)
+        # indicate a corrupt EnergySystem and must not be silently swallowed.
+        validation = self._validate_energy_system(energy_system)
+        for warning in validation.warnings:
+            self.logger.warning("Energy system validation: %s", warning)
+        if not validation.is_valid:
+            for error in validation.errors:
+                self.logger.error("Energy system validation error: %s", error)
+            raise ValidationError(
+                f"Energy system failed structural validation: {validation.errors}"
+            )
+
         return energy_system
 
-    def validate_source(
-        self, source: str | Path | MesidoResultsProtocol | SimulatorResultsProtocol
-    ) -> ValidationResult:
+    def validate_source(self, source: str) -> ValidationResult:  # type: ignore[override]
         """Validate ESDL file path and basic structure.
 
         Args:
-            source: Path to ESDL file
+            source: Path to ESDL file as a string (Path objects are normalised to str
+                by ``load_data`` before this method is called).
 
         Returns:
             ValidationResult indicating if source is valid

--- a/src/kpicalculator/adapters/simulator_adapter.py
+++ b/src/kpicalculator/adapters/simulator_adapter.py
@@ -1,0 +1,196 @@
+# src/kpicalculator/adapters/simulator_adapter.py
+"""Adapter for OMOTES Simulator results."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pandas as pd  # type: ignore[import-untyped]
+from esdl import esdl  # type: ignore[import-untyped]
+from esdl.esdl_handler import EnergySystemHandler  # type: ignore[import-untyped]
+
+from ..exceptions import ValidationError
+from .base_adapter import BaseAdapter, ValidationResult
+from .common_model import EnergySystem
+
+logger = logging.getLogger(__name__)
+
+
+class SimulatorAdapter(BaseAdapter):
+    """Adapter for OMOTES Simulator results.
+
+    Converts the simulator's port-indexed DataFrame to the asset-indexed common
+    model expected by the KPI calculators.
+
+    The simulator produces a DataFrame with ``(port_id, property_name)`` tuple
+    columns — one column per simulated property per port. The KPI calculator
+    works in terms of assets, not ports. This adapter bridges the two
+    representations by resolving port IDs to their owning assets via ESDL
+    object tree traversal, then delegates cost and asset extraction to
+    :class:`~kpicalculator.adapters.esdl_adapter.EsdlAdapter`.
+
+    Keeping this logic inside the adapter means that if the KPI calculator's
+    internal time series contract (e.g. ``KNOWN_TIME_SERIES_FIELDS``) changes,
+    only this adapter needs updating — not the simulator worker.
+
+    Usage::
+
+        adapter = SimulatorAdapter()
+        energy_system = adapter.load_data(simulator_result_df, esdl_string=input_esdl)
+        kpi_manager = KpiManager()
+        kpi_manager.energy_system = energy_system
+        results = kpi_manager.calculate_all_kpis()
+    """
+
+    def load_data(  # type: ignore[override]  # narrows source: Any → pd.DataFrame intentionally
+        self,
+        source: pd.DataFrame,
+        esdl_string: str,
+        **kwargs: Any,
+    ) -> EnergySystem:
+        """Load simulator results into the common model.
+
+        Args:
+            source: DataFrame produced by the simulator, with a DatetimeIndex
+                and columns as ``(port_id, property_name)`` tuples.
+            esdl_string: The input ESDL as an XML string, used both to resolve
+                port IDs to their owning assets and to extract cost / system data.
+
+        Returns:
+            EnergySystem with asset costs from ESDL and time series from the
+            simulator DataFrame.
+
+        Raises:
+            ValidationError: If ``esdl_string`` is empty or ``source`` is not a
+                DataFrame containing ``(port_id, property_name)`` tuple columns.
+        """
+        if not esdl_string.strip():
+            raise ValidationError("esdl_string is required for SimulatorAdapter.load_data()")
+
+        validation = self.validate_source(source)
+        if not validation.is_valid:
+            raise ValidationError(f"Invalid simulator result: {validation.errors}")
+
+        # Parse once — reuse the same object for both port→asset resolution
+        # and cost extraction via EsdlAdapter.load_from_esdl_object().
+        esh = EnergySystemHandler()
+        try:
+            es = esh.load_from_string(esdl_string)
+        except Exception as e:
+            raise ValidationError(f"Failed to parse ESDL string: {e}") from e
+
+        # Convert (port_id, property) columns → asset_id-keyed DataFrames.
+        timeseries_by_asset = self._convert_to_asset_dataframes(source, es)
+
+        # Delegate to EsdlAdapter for asset/cost extraction, passing the
+        # already-parsed object so no second XML parse is needed.
+        from .esdl_adapter import EsdlAdapter
+
+        return EsdlAdapter().load_from_esdl_object(
+            es,
+            timeseries_dataframes=timeseries_by_asset,
+        )
+
+    def validate_source(self, source: Any) -> ValidationResult:  # type: ignore[override]
+        """Validate the simulator result DataFrame.
+
+        Args:
+            source: Expected to be a pandas DataFrame with ``(port_id, property_name)``
+                tuple columns.
+
+        Returns:
+            ValidationResult indicating if the source is usable.
+        """
+        errors: list[str] = []
+        warnings: list[str] = []
+
+        if not isinstance(source, pd.DataFrame):
+            errors.append(
+                f"SimulatorAdapter expects a pandas DataFrame, got {type(source).__name__}"
+            )
+            return ValidationResult(False, errors, warnings)
+
+        if source.empty:
+            warnings.append("Simulator result DataFrame is empty — no time series will be loaded")
+            return ValidationResult(True, errors, warnings)
+
+        tuple_columns = [col for col in source.columns if isinstance(col, tuple) and len(col) == 2]
+        if not tuple_columns:
+            warnings.append(
+                "No (port_id, property_name) tuple columns found in simulator result. "
+                "Ensure the DataFrame uses the simulator's MultiIndex column format."
+            )
+
+        return ValidationResult(True, errors, warnings)
+
+    def get_supported_source_type(self) -> str:
+        """Return identifier for the simulator adapter."""
+        return "simulator"
+
+    def get_supported_parameters(self) -> list[str]:
+        """Return optional parameter names accepted by load_data beyond ``source``."""
+        return ["esdl_string"]
+
+    def _convert_to_asset_dataframes(
+        self,
+        simulator_result: pd.DataFrame,
+        energy_system: esdl.EnergySystem,
+    ) -> dict[str, pd.DataFrame]:
+        """Map ``(port_id, property)`` columns to asset-id-keyed DataFrames.
+
+        For each ``(port_id, property_name)`` column:
+
+        1. Find the asset that owns ``port_id`` via ESDL tree traversal.
+        2. Append the column to that asset's DataFrame under ``property_name``.
+
+        Columns that are not 2-tuples are skipped silently (e.g. a plain
+        ``"datetime"`` column that was not yet converted to a DatetimeIndex).
+        Ports that cannot be matched to any asset are skipped with a warning.
+
+        Args:
+            simulator_result: Simulator output DataFrame.
+            energy_system: Parsed ESDL energy system for port-to-asset lookup.
+
+        Returns:
+            Dict mapping ``asset_id`` → time-indexed DataFrame of property columns.
+        """
+        # Build a port_id → asset_id lookup once so each column resolves in O(1)
+        # rather than walking the full ESDL tree for every (port, property) column.
+        port_to_asset: dict[str, str] = {
+            port.id: item.id
+            for item in energy_system.eAllContents()
+            if isinstance(item, esdl.Asset)
+            for port in item.port
+        }
+
+        asset_data: dict[str, pd.DataFrame] = {}
+        processed = 0
+        skipped = 0
+
+        for col in simulator_result.columns:
+            if not isinstance(col, tuple) or len(col) != 2:
+                continue
+            port_id, property_name = col
+            asset_id = port_to_asset.get(port_id)
+            if asset_id is None:
+                logger.warning(
+                    "Could not find asset for port %s (property %s) — skipped",
+                    port_id,
+                    property_name,
+                )
+                skipped += 1
+                continue
+            processed += 1
+
+            if asset_id not in asset_data:
+                asset_data[asset_id] = pd.DataFrame(index=simulator_result.index)
+            asset_data[asset_id][property_name] = simulator_result[col]
+
+        logger.info(
+            "Converted simulator format: %d assets, %d properties processed, %d skipped",
+            len(asset_data),
+            processed,
+            skipped,
+        )
+        return asset_data

--- a/src/kpicalculator/kpi_manager.py
+++ b/src/kpicalculator/kpi_manager.py
@@ -6,6 +6,8 @@ import pandas as pd  # type: ignore[import-untyped]
 from esdl import esdl
 
 from .adapters.common_model import EnergySystem
+from .adapters.esdl_adapter import EsdlAdapter
+from .adapters.simulator_adapter import SimulatorAdapter
 from .common.constants import DEFAULT_SYSTEM_LIFETIME_YEARS
 
 _logger = logging.getLogger(__name__)
@@ -67,6 +69,10 @@ class KpiManager:
 
         Cost data is extracted from ESDL costInformation elements.
 
+        Note:
+            InfluxDB profile loading is disabled here. To enable it, call
+            ``EsdlAdapter().load_data(..., use_database_profiles=True)`` directly.
+
         Args:
             esdl_file: Path to ESDL file
             time_series_file: Optional path to time series file (when
@@ -75,14 +81,12 @@ class KpiManager:
                 DataFrames with time-indexed energy/power data. When provided,
                 takes precedence over database loading and time_series_file.
         """
-        from .adapters.esdl_adapter import EsdlAdapter
-
         adapter = EsdlAdapter()
         self.energy_system = adapter.load_data(
             esdl_file,
             time_series_file=time_series_file,
             timeseries_dataframes=timeseries_dataframes,
-            use_database_profiles=False,  # Disable database profiles for testing
+            use_database_profiles=False,
         )
         self.source_esdl_file = esdl_file
 
@@ -104,8 +108,6 @@ class KpiManager:
             timeseries_dataframes: Optional dict mapping asset IDs to pandas
                 DataFrames with time-indexed energy/power data.
         """
-        from .adapters.esdl_adapter import EsdlAdapter
-
         adapter = EsdlAdapter()
         self.energy_system = adapter.load_from_string(
             esdl_string,
@@ -113,14 +115,25 @@ class KpiManager:
         )
         self.source_esdl_file = None
 
-    def load_from_simulator(self, simulator_data: Any) -> None:
-        """Load energy system data from simulator data structure.
+    def load_from_simulator(
+        self,
+        simulator_result: pd.DataFrame,
+        esdl_string: str,
+    ) -> None:
+        """Load energy system data from OMOTES Simulator results.
+
+        Converts the simulator's port-indexed DataFrame to the asset-indexed
+        common model and extracts cost data from the supplied ESDL string.
 
         Args:
-            simulator_data: Simulator data structure
+            simulator_result: DataFrame produced by the simulator, with a
+                DatetimeIndex and ``(port_id, property_name)`` tuple columns.
+            esdl_string: The input ESDL as an XML string, used to resolve
+                port IDs to their owning assets and to extract cost data.
         """
-        # TODO: Implement simulator adapter
-        raise NotImplementedError("Simulator adapter not implemented yet")
+        adapter = SimulatorAdapter()
+        self.energy_system = adapter.load_data(simulator_result, esdl_string=esdl_string)
+        self.source_esdl_file = None
 
     def load_from_mesido(self, mesido_data: Any) -> None:
         """Load energy system data from mesido data structure.

--- a/unit_test/test_esdl_adapter.py
+++ b/unit_test/test_esdl_adapter.py
@@ -146,12 +146,29 @@ class TestLoadDataErrorPaths(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.adapter.load_data(source=42)
 
-    def test_non_path_source_mesido_mock_raises_type_error(self) -> None:
-        """A mock MesidoResultsProtocol also triggers the TypeError branch."""
-        mock_mesido = MagicMock()
-        # It is not a str or Path, so load_data must raise TypeError
+    def test_non_path_source_arbitrary_object_raises_type_error(self) -> None:
+        """Any non-str/Path object triggers the TypeError branch.
+
+        EsdlAdapter only accepts file paths. Passing any other type should raise
+        TypeError immediately, before any file I/O is attempted.
+        """
+        mock_data = MagicMock()
         with self.assertRaises(TypeError):
-            self.adapter.load_data(source=mock_mesido)
+            self.adapter.load_data(source=mock_data)
+
+    def test_dataframe_source_raises_type_error_with_clear_message(self) -> None:
+        """Passing a DataFrame raises TypeError with the actual type name in the message.
+
+        This is the most likely caller mistake: using EsdlAdapter instead of
+        SimulatorAdapter when the source is a simulator result DataFrame.
+        """
+        import pandas as pd
+
+        df = pd.DataFrame()
+        with self.assertRaises(TypeError) as ctx:
+            self.adapter.load_data(source=df)
+
+        self.assertIn("DataFrame", str(ctx.exception))
 
     def test_invalid_esdl_path_raises_value_error(self) -> None:
         """load_data() raises ValueError when validate_source() returns errors.

--- a/unit_test/test_simulator_adapter.py
+++ b/unit_test/test_simulator_adapter.py
@@ -1,0 +1,316 @@
+# unit_test/test_simulator_adapter.py
+"""Unit tests for SimulatorAdapter.
+
+Coverage groups:
+  validate_source()
+    - Non-DataFrame input          → is_valid=False
+    - Empty DataFrame              → is_valid=True, warning emitted
+    - DataFrame with no 2-tuples   → is_valid=True, warning emitted
+    - Well-formed DataFrame        → is_valid=True, no warnings
+
+  get_supported_source_type / get_supported_parameters
+    - Return the expected strings
+
+  _convert_to_asset_dataframes()
+    - Non-tuple columns skipped (no crash)
+    - Multiple properties for same asset merged into one DataFrame
+    - Unknown port skipped (warning, not crash)
+
+  load_data() error paths
+    - Empty / whitespace esdl_string → ValidationError
+    - Non-DataFrame source           → ValidationError
+    - Unparseable ESDL string        → ValidationError
+
+  load_data() integration
+    - Correct timeseries_dataframes shape passed to EsdlAdapter.load_from_string
+    - Returns the EnergySystem produced by EsdlAdapter
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+from esdl import esdl
+from esdl.esdl_handler import EnergySystemHandler
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_ESDL_ONE_ASSET = """<?xml version='1.0' encoding='UTF-8'?>
+<esdl:EnergySystem xmlns:esdl="http://www.tno.nl/esdl"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   id="es-1" name="TestSystem">
+  <instance id="inst-1">
+    <area id="area-1">
+      <asset xsi:type="esdl:GeothermalSource" id="asset-1" name="Geo1">
+        <port xsi:type="esdl:OutPort" id="port-out-1" name="Out"/>
+      </asset>
+    </area>
+  </instance>
+</esdl:EnergySystem>"""
+
+_ESDL_TWO_ASSETS = """<?xml version='1.0' encoding='UTF-8'?>
+<esdl:EnergySystem xmlns:esdl="http://www.tno.nl/esdl"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   id="es-2" name="TestSystem2">
+  <instance id="inst-1">
+    <area id="area-1">
+      <asset xsi:type="esdl:GeothermalSource" id="asset-1" name="Geo1">
+        <port xsi:type="esdl:OutPort" id="port-out-1" name="Out"/>
+      </asset>
+      <asset xsi:type="esdl:HeatingDemand" id="asset-2" name="Demand1">
+        <port xsi:type="esdl:InPort" id="port-in-2" name="In"/>
+      </asset>
+    </area>
+  </instance>
+</esdl:EnergySystem>"""
+
+
+def _parse_esdl(esdl_string: str) -> esdl.EnergySystem:
+    esh = EnergySystemHandler()
+    return esh.load_from_string(esdl_string)
+
+
+def _make_df(**columns) -> pd.DataFrame:
+    """Build a small time-indexed DataFrame from keyword args mapping column → values.
+
+    Scoped to this module. test_kpi_calculator.py has its own instance-method
+    variant — the two are independent and serve different fixture shapes.
+    """
+    index = pd.date_range("2024-01-01", periods=3, freq="h")
+    return pd.DataFrame(columns, index=index)
+
+
+# ---------------------------------------------------------------------------
+# validate_source()
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSource(unittest.TestCase):
+    """validate_source() covers the input type and shape checks."""
+
+    def setUp(self) -> None:
+        from kpicalculator.adapters.simulator_adapter import SimulatorAdapter
+
+        self.adapter = SimulatorAdapter()
+
+    def test_non_dataframe_is_invalid(self) -> None:
+        """Passing anything that is not a DataFrame must return is_valid=False."""
+        result = self.adapter.validate_source("not a dataframe")
+        self.assertFalse(result.is_valid)
+        self.assertTrue(result.errors)
+
+    def test_empty_dataframe_is_valid_with_warning(self) -> None:
+        """An empty DataFrame is accepted but warrants a warning."""
+        result = self.adapter.validate_source(pd.DataFrame())
+        self.assertTrue(result.is_valid)
+        self.assertTrue(result.warnings)
+        self.assertTrue(any("empty" in w.lower() for w in result.warnings))
+
+    def test_dataframe_without_tuple_columns_is_valid_with_warning(self) -> None:
+        """A non-empty DataFrame with no (port_id, property) columns produces a warning."""
+        df = _make_df(column_a=[1, 2, 3])
+        result = self.adapter.validate_source(df)
+        self.assertTrue(result.is_valid)
+        self.assertTrue(any("tuple" in w.lower() or "port" in w.lower() for w in result.warnings))
+
+    def test_well_formed_dataframe_is_valid_no_warnings(self) -> None:
+        """A DataFrame with (port_id, property_name) tuple columns passes cleanly."""
+        df = _make_df()
+        df[("port-1", "Heat_GJ")] = [10.0, 20.0, 30.0]
+        result = self.adapter.validate_source(df)
+        self.assertTrue(result.is_valid)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.warnings, [])
+
+
+# ---------------------------------------------------------------------------
+# get_supported_source_type / get_supported_parameters
+# ---------------------------------------------------------------------------
+
+
+class TestMetadata(unittest.TestCase):
+    def setUp(self) -> None:
+        from kpicalculator.adapters.simulator_adapter import SimulatorAdapter
+
+        self.adapter = SimulatorAdapter()
+
+    def test_source_type(self) -> None:
+        self.assertEqual(self.adapter.get_supported_source_type(), "simulator")
+
+    def test_supported_parameters(self) -> None:
+        self.assertIn("esdl_string", self.adapter.get_supported_parameters())
+
+
+# ---------------------------------------------------------------------------
+# _convert_to_asset_dataframes()
+# ---------------------------------------------------------------------------
+
+
+class TestConvertToAssetDataframes(unittest.TestCase):
+    """Port→asset reindexing logic."""
+
+    def setUp(self) -> None:
+        from kpicalculator.adapters.simulator_adapter import SimulatorAdapter
+
+        self.adapter = SimulatorAdapter()
+        self.es = _parse_esdl(_ESDL_ONE_ASSET)
+
+    def test_known_port_maps_to_asset(self) -> None:
+        """A column (port-out-1, Heat_GJ) ends up in asset_data['asset-1']['Heat_GJ']."""
+        df = _make_df()
+        df[("port-out-1", "Heat_GJ")] = [100.0, 200.0, 300.0]
+
+        result = self.adapter._convert_to_asset_dataframes(df, self.es)
+
+        self.assertIn("asset-1", result)
+        self.assertIn("Heat_GJ", result["asset-1"].columns)
+
+    def test_multiple_properties_same_asset_merged(self) -> None:
+        """Two properties for the same port both end up in one asset DataFrame."""
+        df = _make_df()
+        df[("port-out-1", "Heat_GJ")] = [1.0, 2.0, 3.0]
+        df[("port-out-1", "Flow_m3s")] = [0.1, 0.2, 0.3]
+
+        result = self.adapter._convert_to_asset_dataframes(df, self.es)
+
+        self.assertIn("asset-1", result)
+        self.assertIn("Heat_GJ", result["asset-1"].columns)
+        self.assertIn("Flow_m3s", result["asset-1"].columns)
+
+    def test_non_tuple_columns_skipped(self) -> None:
+        """Plain string columns (e.g. 'datetime') are silently ignored."""
+        df = _make_df(datetime=["a", "b", "c"])
+        df[("port-out-1", "Heat_GJ")] = [1.0, 2.0, 3.0]
+
+        result = self.adapter._convert_to_asset_dataframes(df, self.es)
+
+        # 'datetime' must not appear as an asset key
+        self.assertNotIn("datetime", result)
+        self.assertIn("asset-1", result)
+
+    def test_unknown_port_skipped_with_no_crash(self) -> None:
+        """A port ID not present in the ESDL is skipped (warning logged, no exception)."""
+        df = _make_df()
+        df[("unknown-port", "Heat_GJ")] = [1.0, 2.0, 3.0]
+
+        result = self.adapter._convert_to_asset_dataframes(df, self.es)
+
+        self.assertEqual(result, {})
+
+    def test_index_preserved(self) -> None:
+        """The time index from the source DataFrame is preserved in the output."""
+        df = _make_df()
+        df[("port-out-1", "Heat_GJ")] = [5.0, 6.0, 7.0]
+
+        result = self.adapter._convert_to_asset_dataframes(df, self.es)
+
+        pd.testing.assert_index_equal(result["asset-1"].index, df.index)
+
+
+# ---------------------------------------------------------------------------
+# load_data() — error paths
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDataErrors(unittest.TestCase):
+    """load_data() must fail fast with clear exceptions for invalid inputs."""
+
+    def setUp(self) -> None:
+        from kpicalculator.adapters.simulator_adapter import SimulatorAdapter
+
+        self.adapter = SimulatorAdapter()
+
+    def test_empty_esdl_string_raises_validation_error(self) -> None:
+        from kpicalculator.exceptions import ValidationError
+
+        df = pd.DataFrame()
+        with self.assertRaises(ValidationError):
+            self.adapter.load_data(df, esdl_string="")
+
+    def test_whitespace_esdl_string_raises_validation_error(self) -> None:
+        """Whitespace-only strings are caught by the .strip() guard before parsing."""
+        from kpicalculator.exceptions import ValidationError
+
+        df = pd.DataFrame()
+        with self.assertRaises(ValidationError):
+            self.adapter.load_data(df, esdl_string="   ")
+
+    def test_non_dataframe_source_raises_validation_error(self) -> None:
+        from kpicalculator.exceptions import ValidationError
+
+        with self.assertRaises(ValidationError):
+            self.adapter.load_data("not a dataframe", esdl_string=_ESDL_ONE_ASSET)
+
+    def test_unparseable_esdl_raises_validation_error(self) -> None:
+        from kpicalculator.exceptions import ValidationError
+
+        df = _make_df()
+        df[("port-out-1", "Heat_GJ")] = [1.0, 2.0, 3.0]
+        with self.assertRaises(ValidationError):
+            self.adapter.load_data(df, esdl_string="<not valid esdl xml")
+
+
+# ---------------------------------------------------------------------------
+# load_data() — integration (EsdlAdapter delegated correctly)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDataIntegration(unittest.TestCase):
+    """load_data() must pass the correctly shaped timeseries_dataframes to EsdlAdapter."""
+
+    def setUp(self) -> None:
+        from kpicalculator.adapters.simulator_adapter import SimulatorAdapter
+
+        self.adapter = SimulatorAdapter()
+
+    def test_timeseries_dataframes_passed_to_esdl_adapter(self) -> None:
+        """The asset-keyed DataFrames produced by _convert_to_asset_dataframes are
+        forwarded unchanged to EsdlAdapter.load_from_esdl_object."""
+        df = _make_df()
+        df[("port-out-1", "Heat_GJ")] = [1.0, 2.0, 3.0]
+
+        mock_energy_system = MagicMock()
+
+        with patch("kpicalculator.adapters.esdl_adapter.EsdlAdapter") as MockEsdlAdapter:
+            MockEsdlAdapter.return_value.load_from_esdl_object.return_value = mock_energy_system
+
+            result = self.adapter.load_data(df, esdl_string=_ESDL_ONE_ASSET)
+
+        MockEsdlAdapter.return_value.load_from_esdl_object.assert_called_once()
+        call_kwargs = MockEsdlAdapter.return_value.load_from_esdl_object.call_args
+
+        # First positional arg is the parsed esdl.EnergySystem object (not the string)
+        self.assertIsNotNone(call_kwargs.args[0])
+
+        # timeseries_dataframes must be a dict keyed by asset ID
+        ts_dfs = call_kwargs.kwargs["timeseries_dataframes"]
+        self.assertIsInstance(ts_dfs, dict)
+        self.assertIn("asset-1", ts_dfs)
+        self.assertIn("Heat_GJ", ts_dfs["asset-1"].columns)
+
+        # Return value is whatever EsdlAdapter produced
+        self.assertIs(result, mock_energy_system)
+
+    def test_empty_dataframe_delegates_to_esdl_adapter(self) -> None:
+        """An empty source DataFrame still delegates to EsdlAdapter (with empty ts dict)."""
+        df = pd.DataFrame()
+        mock_energy_system = MagicMock()
+
+        with patch("kpicalculator.adapters.esdl_adapter.EsdlAdapter") as MockEsdlAdapter:
+            MockEsdlAdapter.return_value.load_from_esdl_object.return_value = mock_energy_system
+
+            result = self.adapter.load_data(df, esdl_string=_ESDL_ONE_ASSET)
+
+        ts_dfs = MockEsdlAdapter.return_value.load_from_esdl_object.call_args.kwargs[
+            "timeseries_dataframes"
+        ]
+        self.assertEqual(ts_dfs, {})
+        self.assertIs(result, mock_energy_system)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

Add SimulatorAdapter to convert the OMOTES Simulator's port-indexed DataFrame to the asset-indexed common model. Implement KpiManager.load_from_simulator() as the public entry point.

Changes:

BaseAdapter
- Remove unused protocol stubs (MesidoResultsProtocol, SimulatorResultsProtocol)
- Narrow load_data to (source: Any, **kwargs) — each adapter narrows source to its own input type with # type: ignore[override]

EsdlAdapter
- Add load_from_esdl_object() to accept a pre-parsed PyESDL object, avoiding a second XML parse when the caller already holds one
- Raise ValidationError when structural validation fails (was silently logged)
- Fix TypeError message to include the actual type name

SimulatorAdapter (new)
- Resolves port IDs to asset IDs via ESDL tree traversal
- Parses the ESDL string once and passes the object to load_from_esdl_object()
- Guards against whitespace-only esdl_string inputs

KpiManager
- Implement load_from_simulator(simulator_result, esdl_string)
- Move use_database_profiles=False note to a docstring Note: section

Tests
- Add test_simulator_adapter.py
- Add test_dataframe_source_raises_type_error_with_clear_message to test_esdl_adapter.py

Docs
- Update architecture.rst: adapter diagram, project layout, and the "Adding a New Adapter" guide to reflect the narrowing pattern