### PR TITLE
docs: use uv sync to install docs dependencies in ReadTheDocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,16 +7,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  jobs:
-    pre_install:
-      - pip install uv
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-
-sphinx:
-  configuration: doc/conf.py
+  commands:
+    - pip install uv
+    - uv sync --group docs --frozen
+    - uv run python -m sphinx -T -b html -d $READTHEDOCS_OUTPUT/doctrees -D language=en doc $READTHEDOCS_OUTPUT/html

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -136,7 +136,7 @@ Export calculated KPIs back into ESDL as ``DistributionKPI`` elements for visual
 
 .. code-block:: python
 
-   esdl_with_kpis = manager.get_esdl_with_kpis(results)
+   esdl_with_kpis = manager.build_esdl_with_kpis(results)
 
 .. note::
    Both export patterns are validated by `test_string_loaded_esdl_export <https://github.com/Project-OMOTES/kpi-calculator/blob/v0.3.0/unit_test/test_examples.py>`_ in |test_examples|.


### PR DESCRIPTION
  - ReadTheDocs was using pip to install the docs extra, which failed to resolve sphinx_copybutton and other Sphinx
  dependencies. The fix switches to `uv sync --group docs` with an explicit Sphinx build command, consistent with how
  dependencies are managed in the rest of the project.
 - Fix typo due to stale API reference in getting_started.rst: get_esdl_with_kpis → build_esdl_with_kpis