### PR TITLE
   fix: clean up dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "coloredlogs~=15.0.1",
     "numpy>=2.1.0,<3.0", # Compatible with simulator-worker
     "pandas>=2.2.2,<3.0", # Requires pandas >=2.2.2 for numpy 2.x compatibility
-    "pandas-stubs", # Type stubs for pandas
     "pyesdl~=25.7", # Compatible with simulator-worker
     "xmltodict==0.14.2",
-    "types-xmltodict", # Type stubs for xmltodict
     "influxdb>=5.3.2",
     "pydantic>=2.0.0,<3.0", # Modern data validation with type hints
     "urllib3>=2.6.3", # Security: CVE fixes in 2.6.3+
@@ -46,12 +43,12 @@ lint = [
     "ruff>=0.6.0",
     "mypy ~= 1.5.1",
     "pre-commit ~= 3.6.0",
+    "pandas-stubs", # Type stubs for pandas
+    "types-xmltodict", # Type stubs for xmltodict
 ]
 analysis = [
     "codespell>=2.0.0",    # Spell checking
     "vulture>=2.0.0",      # Dead code detection
-    "bandit>=1.7.0",       # Security vulnerability scanner
-    "radon>=6.0.0",        # Code complexity analysis
     "pylint>=3.0.0",       # Duplicate code detection (run with --disable=all --enable=similarities)
     "pipdeptree>=2.0.0",   # Dependency analysis and visualization
     "pip-audit>=2.0.0",    # Official Python package vulnerability scanner
@@ -176,7 +173,7 @@ exclude = ['.venv/*', 'venv/*', 'doc/*', 'ci/*']
 
 # mypy per-module options:
 [[tool.mypy.overrides]]
-module = ["unit_test.*", "coloredlogs.*", "pandas.*", "xmltodict.*", "esdl.*", "esdl.esdl_handler.*", "jinja2.*"]
+module = ["unit_test.*", "pandas.*", "xmltodict.*", "esdl.*", "esdl.esdl_handler.*", "jinja2.*"]
 check_untyped_defs = true
 ignore_missing_imports = true
 

--- a/uv.lock
+++ b/uv.lock
@@ -64,21 +64,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bandit"
-version = "1.8.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "stevedore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/b5/7eb834e213d6f73aace21938e5e90425c92e5f42abafaf8a6d5d21beed51/bandit-1.8.6.tar.gz", hash = "sha256:dbfe9c25fc6961c2078593de55fd19f2559f9e45b99f1272341f5b95dea4e56b", size = 4240271, upload-time = "2025-07-06T03:10:50.9Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/ca/ba5f909b40ea12ec542d5d7bdd13ee31c4d65f3beed20211ef81c18fa1f3/bandit-1.8.6-py3-none-any.whl", hash = "sha256:3348e934d736fcdb68b6aa4030487097e23a501adf3e7827b63658df464dddd0", size = 133808, upload-time = "2025-07-06T03:10:49.134Z" },
-]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -228,18 +213,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "coloredlogs"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "humanfriendly" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
 
 [[package]]
@@ -418,18 +391,6 @@ wheels = [
 ]
 
 [[package]]
-name = "humanfriendly"
-version = "10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
-]
-
-[[package]]
 name = "hypothesis"
 version = "6.139.2"
 source = { registry = "https://pypi.org/simple" }
@@ -519,27 +480,22 @@ wheels = [
 name = "kpi-calculator"
 source = { editable = "." }
 dependencies = [
-    { name = "coloredlogs" },
     { name = "filelock" },
     { name = "influxdb" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "pandas-stubs" },
     { name = "pydantic" },
     { name = "pyesdl" },
-    { name = "types-xmltodict" },
     { name = "urllib3" },
     { name = "xmltodict" },
 ]
 
 [package.dev-dependencies]
 analysis = [
-    { name = "bandit" },
     { name = "codespell" },
     { name = "pip-audit" },
     { name = "pipdeptree" },
     { name = "pylint" },
-    { name = "radon" },
     { name = "vulture" },
 ]
 build = [
@@ -551,13 +507,13 @@ build = [
     { name = "wheel" },
 ]
 dev = [
-    { name = "bandit" },
     { name = "build" },
     { name = "bump2version" },
     { name = "codespell" },
     { name = "furo" },
     { name = "hypothesis" },
     { name = "mypy" },
+    { name = "pandas-stubs" },
     { name = "pip" },
     { name = "pip-audit" },
     { name = "pipdeptree" },
@@ -566,7 +522,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
-    { name = "radon" },
     { name = "ruff" },
     { name = "setuptools" },
     { name = "setuptools-git-versioning" },
@@ -575,6 +530,7 @@ dev = [
     { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx-autodoc-typehints", version = "3.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-copybutton" },
+    { name = "types-xmltodict" },
     { name = "vulture" },
     { name = "wheel" },
 ]
@@ -588,8 +544,10 @@ docs = [
 ]
 lint = [
     { name = "mypy" },
+    { name = "pandas-stubs" },
     { name = "pre-commit" },
     { name = "ruff" },
+    { name = "types-xmltodict" },
 ]
 test = [
     { name = "hypothesis" },
@@ -600,27 +558,22 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coloredlogs", specifier = "~=15.0.1" },
     { name = "filelock", specifier = ">=3.20.1" },
     { name = "influxdb", specifier = ">=5.3.2" },
     { name = "numpy", specifier = ">=2.1.0,<3.0" },
     { name = "pandas", specifier = ">=2.2.2,<3.0" },
-    { name = "pandas-stubs" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0" },
     { name = "pyesdl", specifier = "~=25.7" },
-    { name = "types-xmltodict" },
     { name = "urllib3", specifier = ">=2.6.3" },
     { name = "xmltodict", specifier = "==0.14.2" },
 ]
 
 [package.metadata.requires-dev]
 analysis = [
-    { name = "bandit", specifier = ">=1.7.0" },
     { name = "codespell", specifier = ">=2.0.0" },
     { name = "pip-audit", specifier = ">=2.0.0" },
     { name = "pipdeptree", specifier = ">=2.0.0" },
     { name = "pylint", specifier = ">=3.0.0" },
-    { name = "radon", specifier = ">=6.0.0" },
     { name = "vulture", specifier = ">=2.0.0" },
 ]
 build = [
@@ -632,13 +585,13 @@ build = [
     { name = "wheel", specifier = "~=0.46.2" },
 ]
 dev = [
-    { name = "bandit", specifier = ">=1.7.0" },
     { name = "build", specifier = "~=1.0.3" },
     { name = "bump2version", specifier = "==1.0.1" },
     { name = "codespell", specifier = ">=2.0.0" },
     { name = "furo", specifier = ">=2023.1.0" },
     { name = "hypothesis", specifier = ">=6.0.0" },
     { name = "mypy", specifier = "~=1.5.1" },
+    { name = "pandas-stubs" },
     { name = "pip", specifier = ">=25.3" },
     { name = "pip-audit", specifier = ">=2.0.0" },
     { name = "pipdeptree", specifier = ">=2.0.0" },
@@ -647,13 +600,13 @@ dev = [
     { name = "pytest", specifier = "~=7.3.1" },
     { name = "pytest-cov", specifier = "~=4.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.0" },
-    { name = "radon", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.6.0" },
     { name = "setuptools", specifier = ">=70.0.0" },
     { name = "setuptools-git-versioning", specifier = "<2" },
     { name = "sphinx", specifier = ">=5.3" },
     { name = "sphinx-autodoc-typehints", specifier = ">=1.18.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.0" },
+    { name = "types-xmltodict" },
     { name = "vulture", specifier = ">=2.0.0" },
     { name = "wheel", specifier = "~=0.46.2" },
 ]
@@ -665,8 +618,10 @@ docs = [
 ]
 lint = [
     { name = "mypy", specifier = "~=1.5.1" },
+    { name = "pandas-stubs" },
     { name = "pre-commit", specifier = "~=3.6.0" },
     { name = "ruff", specifier = ">=0.6.0" },
+    { name = "types-xmltodict" },
 ]
 test = [
     { name = "hypothesis", specifier = ">=6.0.0" },
@@ -767,18 +722,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/ea/048dea6cdfc7a72d40ae8ed7e7d23cf4a6b6a6547b51b492a3be50af0e80/lxml-6.0.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:445f2cee71c404ab4259bc21e20339a859f75383ba2d7fb97dfe7c163994287b", size = 4270228, upload-time = "2025-08-22T10:37:47.276Z" },
     { url = "https://files.pythonhosted.org/packages/6b/d4/c2b46e432377c45d611ae2f669aa47971df1586c1a5240675801d0f02bac/lxml-6.0.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e352d8578e83822d70bea88f3d08b9912528e4c338f04ab707207ab12f4b7aac", size = 4416077, upload-time = "2025-08-22T10:37:49.822Z" },
     { url = "https://files.pythonhosted.org/packages/b6/db/8f620f1ac62cf32554821b00b768dd5957ac8e3fd051593532be5b40b438/lxml-6.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:51bd5d1a9796ca253db6045ab45ca882c09c071deafffc22e06975b7ace36300", size = 3518127, upload-time = "2025-08-22T10:37:51.66Z" },
-]
-
-[[package]]
-name = "mando"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/35/24/cd70d5ae6d35962be752feccb7dca80b5e0c2d450e995b16abd6275f3296/mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500", size = 37868, upload-time = "2022-02-24T08:12:27.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/f0/834e479e47e499b6478e807fb57b31cc2db696c4db30557bb6f5aea4a90b/mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a", size = 28149, upload-time = "2022-02-24T08:12:25.24Z" },
 ]
 
 [[package]]
@@ -1359,15 +1302,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyreadline3"
-version = "3.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "7.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1462,19 +1396,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
-]
-
-[[package]]
-name = "radon"
-version = "6.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama" },
-    { name = "mando" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/6d/98e61600febf6bd929cf04154537c39dc577ce414bafbfc24a286c4fa76d/radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5", size = 1874992, upload-time = "2023-03-26T06:24:38.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/f7/d00d9b4a0313a6be3a3e0818e6375e15da6d7076f4ae47d1324e7ca986a1/radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859", size = 52784, upload-time = "2023-03-26T06:24:33.949Z" },
 ]
 
 [[package]]
@@ -1777,15 +1698,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
-]
-
-[[package]]
-name = "stevedore"
-version = "5.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/5f/8418daad5c353300b7661dd8ce2574b0410a6316a8be650a189d5c68d938/stevedore-5.5.0.tar.gz", hash = "sha256:d31496a4f4df9825e1a1e4f1f74d19abb0154aff311c3b376fcc89dae8fccd73", size = 513878, upload-time = "2025-08-25T12:54:26.806Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/c5/0c06759b95747882bb50abda18f5fb48c3e9b0fbfc6ebc0e23550b52415d/stevedore-5.5.0-py3-none-any.whl", hash = "sha256:18363d4d268181e8e8452e71a38cd77630f345b2ef6b4a8d5614dac5ee0d18cf", size = 49518, upload-time = "2025-08-25T12:54:25.445Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
   - Remove coloredlogs: unused in source code
   - Move pandas-stubs and types-xmltodict from runtime to lint dev dependencies: type stubs have no runtime use and caused version conflicts downstream (e.g. pandas-stubs pin in simulator-worker)
   - Remove radon and bandit from analysis group: both are covered by ruff (C9 for complexity, S ruleset for security)
   - Remove coloredlogs from mypy overrides