### PR TITLE
Expand financial KPIs with per-asset breakdown, EAC, and TCO

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,16 +7,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  jobs:
-    pre_install:
-      - pip install uv
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-
-sphinx:
-  configuration: doc/conf.py
+  commands:
+    - pip install uv
+    - uv sync --group docs --frozen
+    - uv run python -m sphinx -T -b html -d $READTHEDOCS_OUTPUT/doctrees -D language=en doc $READTHEDOCS_OUTPUT/html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,3 +45,13 @@ Quality guidelines serve to improve quality. They should not be busy work nor wo
 - A unit test should test a meaningful unit of behaviour — not a single line, not an entire module.
 - Use mocks to isolate the unit under test where applicable.
 - Coverage must remain above 80%. Breaking this threshold requires agreement from the team, not just the author and reviewer.
+- Structure every test using the **AAA (Arrange-Act-Assert)** pattern, with each section separated by a blank line and labeled with a `# Arrange`, `# Act`, `# Assert` comment. For tests where act and assert cannot be separated (e.g. `assertRaises`), use `# Act & Assert`.
+- Use the **most specific assertion** available for the situation — prefer `assertEqual`, `assertIsInstance`, `assertIsNotNone`, `assertIn` etc. over `assertTrue`/`assertFalse`. Never use bare `assert` statements in test methods; they bypass unittest's error reporting.
+- **Extract magic strings** that appear in assertions to module-level constants (e.g. expected KPI names, error messages). This makes refactoring cheaper and assertion intent clearer.
+- **Extract shared test fixtures** (e.g. factory functions for domain objects) to module-level helper functions when used across multiple test classes. Avoid duplicating fixture logic between test classes.
+- **Extract repeated assertion patterns** to helper methods on the test class (e.g. `_find_distribution_item`, `_get_kpi_count`) to avoid copy-paste in the Assert section.
+- Use `tempfile.TemporaryDirectory` as a **context manager** for temporary file tests. Avoid `setUp`/`tearDown` for resources only needed by a single test — allocate them in the test itself instead.
+- Avoid the **TOCTOU anti-pattern** in cleanup code: do not check for existence before deleting (e.g. `if path.exists(): rmtree(path)`); operate directly and let errors surface if something is wrong.
+- Place imports that are only needed inside a single test method at the top of that method, not at module level, to keep the module's import footprint minimal.
+
+Applying these guidelines to all existing test files is a tracked task — see "Harden Test Suite" item 1 in [`ROADMAP.md`](doc/project_efvc_/kpi_development_documentation/ROADMAP.md).

--- a/doc/api_reference.rst
+++ b/doc/api_reference.rst
@@ -16,6 +16,24 @@ Public API
 .. autoclass:: kpicalculator.KpiManager
    :members:
 
+Result Types
+~~~~~~~~~~~~
+
+.. autoclass:: kpicalculator.KpiResults
+   :members:
+
+.. autoclass:: kpicalculator.FinancialResults
+   :members:
+
+.. autoclass:: kpicalculator.EnergyResults
+   :members:
+
+.. autoclass:: kpicalculator.EmissionResults
+   :members:
+
+.. autoclass:: kpicalculator.AssetFinancialResult
+   :members:
+
 Calculators
 -----------
 

--- a/doc/api_reference.rst
+++ b/doc/api_reference.rst
@@ -19,7 +19,7 @@ Public API
 Calculators
 -----------
 
-.. automodule:: kpicalculator.calculators.cost_calculator
+.. automodule:: kpicalculator.calculators.financial_calculator
    :members:
 
 .. automodule:: kpicalculator.calculators.energy_calculator

--- a/doc/dev_documentation/architecture.rst
+++ b/doc/dev_documentation/architecture.rst
@@ -204,10 +204,20 @@ derived from the field name tuples imported by the calculators:
 
 .. code-block:: text
 
-   CONSUMPTION_FIELDS        ThermalConsumption, Consumption, Energy
+   CONSUMPTION_FIELDS        ThermalConsumption, Consumption, Energy,
+                             heat_power_primary
    DEMAND_FIELDS             ThermalDemand, Demand
-   PRODUCTION_FIELDS         ThermalProduction, Production, Energy
+   PRODUCTION_FIELDS         ThermalProduction, Production, heat_supplied, Energy,
+                             heat_power_secondary
    ELECTRICAL_CONSUMPTION    ElectricalConsumption
+   CONVERSION_FIELDS         ElectricalConsumption, electricity_consumption,
+                             ThermalProduction
+
+``heat_power_primary`` and ``heat_power_secondary`` are the field names emitted by
+``omotes_simulator_core`` for heat pump and heat exchanger assets (primary side = consumer of
+heat, secondary side = producer of heat). ``electricity_consumption`` is the lowercase field
+name used by simulator-core for ``HeatPump`` and ``AirToWaterHeatPump`` assets; it maps to
+``CONVERSION_FIELDS`` alongside the ESDL-native ``ElectricalConsumption``.
 
 Columns with unrecognised names are stored in the time series dict but will not be picked up by
 any calculator — a warning is logged at load time so callers can catch the mismatch early.
@@ -310,7 +320,11 @@ Emission Calculator
 - **Total emissions**: Sum of (emission_factor × energy) per asset, converted to tonnes
 - **Emissions per MWh**: total_emissions / consumption_in_MWh
 
-Emission factors come from ESDL carrier definitions (kg CO2/GJ). The same logging conventions apply: missing data at DEBUG, zero duration at WARNING.
+Emission factors come from ESDL carrier definitions (kg CO2/GJ). Only ``EnergyCarrier``
+assets carry an ``.emission`` attribute; ``HeatCommodity`` and other carrier types do not.
+When a non-``EnergyCarrier`` carrier is encountered, the factor is set to ``0.0`` and a
+DEBUG message is logged — emissions for that asset are not included in the total.
+The same logging conventions apply: missing data at DEBUG, zero duration at WARNING.
 
 ESDL Export
 -----------

--- a/doc/dev_documentation/architecture.rst
+++ b/doc/dev_documentation/architecture.rst
@@ -33,7 +33,7 @@ The package has four layers:
    │    kpi_manager.py → KpiManager                           │
    ├──────────────────────────────────────────────────────────┤
    │  Calculators                                             │
-   │    cost_calculator    energy_calculator    emission_calc  │
+   │    financial_calculator    energy_calculator    emission_calc  │
    ├──────────────────────────────────────────────────────────┤
    │  Adapters                                                │
    │    esdl_adapter    time_series_manager    database_loader │
@@ -216,7 +216,7 @@ Non-numeric columns are rejected with an error recorded in ``ValidationResult`` 
 Cost Unit Conversion
 --------------------
 
-The cost calculator (``calculators/cost_calculator.py``) converts cost values from ESDL units to EUR using the asset's physical properties and built-in conversion factors defined in ``COST_UNIT_FACTORS`` (``common/constants.py``). The factors are looked up by ``_get_unit_factor(unit)`` from ``energy_system.unit_conversion``, which is automatically populated by the adapter.
+The financial calculator (``calculators/financial_calculator.py``) converts cost values from ESDL units to EUR using the asset's physical properties and built-in conversion factors defined in ``COST_UNIT_FACTORS`` (``common/constants.py``). The factors are looked up by ``_get_unit_factor(unit)`` from ``energy_system.unit_conversion``, which is automatically populated by the adapter.
 
 **Investment and installation costs** — allowed units:
 
@@ -263,22 +263,24 @@ All three calculators take an ``EnergySystem`` and return part of the ``KpiResul
 Error Handling
 ^^^^^^^^^^^^^^
 
-All calculators use Python's ``logging`` module with the logger name set to their module path (e.g. ``kpicalculator.calculators.cost_calculator``). Two log levels are used:
+All calculators use Python's ``logging`` module with the logger name set to their module path (e.g. ``kpicalculator.calculators.financial_calculator``). Two log levels are used:
 
 - **DEBUG** — expected missing-data conditions: no time series on an asset, no matching field name in the time series. These are normal when assets lack simulation results.
 - **WARNING** — unexpected or potentially lossy conditions: unsupported cost units (the cost is zeroed), non-positive duration time series (would cause ``ZeroDivisionError`` or incorrect annualization).
 
 In all cases the calculator returns ``0.0`` for the affected asset rather than raising an exception. Input validation (e.g. ``technical_lifetime <= 0``) is handled upstream by ``BaseAdapter._validate_energy_system()`` and is not duplicated in the calculators.
 
-Cost Calculator
-^^^^^^^^^^^^^^^
+Financial Calculator
+^^^^^^^^^^^^^^^^^^^^
 
-``calculators/cost_calculator.py`` — the largest calculator.
+``calculators/financial_calculator.py`` — the largest calculator. The public class is ``FinancialCalculator``.
 
 - **CAPEX**: Sum of (investment + installation) per asset, converted from ESDL units, grouped by asset category (Production, Transport, Storage, Conversion, Consumption, All)
 - **OPEX**: Sum of (fixed_operational + variable_operational + fixed_maintenance + variable_maintenance) per asset
 - **NPV**: Standard discounted cash flow: ``CAPEX + Sum(OPEX_t / (1 + rate/100)^t)`` over system lifetime (default 30 years, 5% discount rate). Includes asset replacement costs when technical lifetime < system lifetime.
-- **LCOE**: ``NPV / discounted_energy_delivered``
+- **LCOE**: ``NPV / discounted_energy_delivered``, computed inside ``FinancialCalculator`` using pre-calculated energy values.
+- **Per-asset financial breakdown**: ``get_asset_financial_breakdown(annual_energy_mwh_by_asset)`` returns per-asset CAPEX, OPEX, NPV, and LCOE as ``AssetFinancialResult`` entries, stored in ``KpiResults["asset_financials"]``.
+- **Category aggregation**: ``aggregate_by_category(asset_results)`` groups per-asset results into the category-level totals (Production, Transport, etc.) stored under ``KpiResults["financials"]``.
 
 Each of the six ``_calculate_*_cost()`` methods validates the unit string against an ``allowed_units`` list. If the unit is not supported, a warning is logged and the cost is returned as ``0.0``. Variable cost methods (operational and maintenance) also guard against zero-duration time series.
 
@@ -347,7 +349,7 @@ Project Layout
    │   ├── database_time_series_loader.py  # InfluxDB integration
    │   └── xml_time_series_adapter.py  # XML time series (testing only)
    ├── calculators/
-   │   ├── cost_calculator.py          # CAPEX, OPEX, NPV, LCOE
+   │   ├── financial_calculator.py          # CAPEX, OPEX, NPV, LCOE
    │   ├── energy_calculator.py        # Consumption, production, efficiency
    │   └── emission_calculator.py      # CO2 emissions
    ├── reporting/

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -32,17 +32,26 @@ The simplest way to calculate KPIs is from an ESDL file:
 .. note::
    Validated by `test_quick_start <https://github.com/Project-OMOTES/kpi-calculator/blob/v0.3.0/unit_test/test_examples.py>`_ in |test_examples|.
 
-By default, the analysis uses a 30-year system lifetime with a 5% discount rate. You can override the system lifetime:
+By default, the analysis uses a 30-year system lifetime with a 5% discount rate. Assets default to a 40-year technical lifetime when not specified in the ESDL. Both lifetime and discount rate can be overridden via ``KpiManager.calculate_all_kpis()``:
 
 .. code-block:: python
 
-   results = calculate_kpis(
-       esdl_file="model.esdl",
-       system_lifetime=25  # Default: 30 years
+   from kpicalculator import KpiManager
+
+   manager = KpiManager()
+   manager.load_from_esdl("model.esdl")
+   results = manager.calculate_all_kpis(
+       system_lifetime=25,   # Default: 30 years
+       discount_rate=3,      # Default: 5 (percent)
    )
+
+``calculate_kpis()`` exposes ``system_lifetime`` but not ``discount_rate``; use ``KpiManager`` directly when you need to override the discount rate.
 
 .. note::
    Validated by `test_basic_usage_with_parameters <https://github.com/Project-OMOTES/kpi-calculator/blob/v0.3.0/unit_test/test_examples.py>`_ in |test_examples|.
+
+.. note::
+   When comparing output against the MESIDO optimizer, pass ``round_up_replacement=False`` to ``calculate_all_kpis()``. Use the default (``True``) for all other purposes. See the ``calculate_all_kpis`` docstring for details.
 
 Providing Time Series
 ---------------------
@@ -155,6 +164,8 @@ internal adapter state:
 .. note::
    Both export patterns are validated by `test_string_loaded_esdl_export <https://github.com/Project-OMOTES/kpi-calculator/blob/v0.3.0/unit_test/test_examples.py>`_ in |test_examples|.
 
+All three export methods accept an optional ``level`` parameter (``'system'``, ``'area'``, or ``'asset'``). Currently all levels write system-wide KPIs to the main area — area-level and asset-level placement are not yet implemented.
+
 Export works with both file-loaded and string-loaded ESDL — no temporary files needed for in-memory workflows.
 
 From OMOTES Simulator Results
@@ -208,19 +219,7 @@ Results Structure
            "per_mwh": 178,        # kg CO2e/MWh
        },
        "asset_financials": {
-           "<asset_id>": {
-               "investment_cost": 500000,
-               "installation_cost": 50000,
-               "fixed_operational_cost": 10000,
-               "variable_operational_cost": 5000,
-               "fixed_maintenance_cost": 2000,
-               "variable_maintenance_cost": 1000,
-               "annualized_capex": 18000,
-               "eac": 36000,
-               "npv": 420000,
-               "tco": 700000,
-               "lcoe": 42.0,       # EUR/MWh — None for non-producing assets
-           },
+           "<asset_id>": { ... },  # per-asset breakdown — see KPI Guide
            ...
        },
    }
@@ -228,7 +227,7 @@ Results Structure
 - **Financials**: Top-level category for all monetary KPIs. This includes cost breakdowns such as CAPEX and OPEX by asset category (Production, Transport, Storage, Conversion, Consumption, and All), as well as derived financial indicators (NPV, LCOE, EAC, TCO). All values are sums over assets.
 - **Energy**: System-wide totals in Joules. Efficiency is the ratio of consumption to production (0 to 1).
 - **Emissions**: Total CO2-equivalent emissions in tonnes and emissions intensity in kg CO2e per MWh of energy consumed.
-- **Asset financials**: Per-asset breakdown of all financial KPIs, keyed by asset ID. System totals in ``"financials"`` are derived by summing these values. ``lcoe`` is ``None`` for non-producing assets (consumers, transport, storage, conversion).
+- **Asset financials**: Per-asset breakdown of all financial KPIs, keyed by asset ID. For field definitions and interpretation, see :ref:`per-asset-financial-kpis` in the KPI Guide.
 
 For a detailed explanation of what each KPI means and how to interpret it, see :doc:`user_documentation/kpi_guide`.
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -26,8 +26,8 @@ The simplest way to calculate KPIs is from an ESDL file:
    from kpicalculator import calculate_kpis
 
    results = calculate_kpis(esdl_file="path/to/model.esdl")
-   print(f"Total CAPEX: {results['costs']['capex']['All']} EUR")
-   print(f"LCOE: {results['costs']['lcoe']} EUR/MWh")
+   print(f"Total CAPEX: {results['financials']['capex']['All']} EUR")
+   print(f"LCOE: {results['financials']['lcoe']} EUR/MWh")
 
 .. note::
    Validated by `test_quick_start <https://github.com/Project-OMOTES/kpi-calculator/blob/v0.3.0/unit_test/test_examples.py>`_ in |test_examples|.
@@ -184,32 +184,51 @@ recognised directly by the energy and emission calculators — no column renamin
 Results Structure
 -----------------
 
-``calculate_kpis()`` returns a dictionary with three categories:
+``calculate_kpis()`` returns a dictionary with four top-level keys:
 
 .. code-block:: python
 
    {
-       "costs": {
+       "financials": {
            "capex": {"All": 1000000, "Production": 500000, "Transport": 300000, ...},
            "opex": {"All": 50000, "Production": 30000, ...},
            "npv": 850000,
-           "lcoe": 45.5
+           "lcoe": 45.5,
+           "eac": 62000,
+           "tco": 1400000,
        },
        "energy": {
            "consumption": 1e10,   # Joules
            "production": 1.1e10,
            "demand": 9.5e9,
-           "efficiency": 0.91
+           "efficiency": 0.91,
        },
        "emissions": {
            "total": 1200,         # tonnes CO2e/year
-           "per_mwh": 178         # kg CO2e/MWh
-       }
+           "per_mwh": 178,        # kg CO2e/MWh
+       },
+       "asset_financials": {
+           "<asset_id>": {
+               "investment_cost": 500000,
+               "installation_cost": 50000,
+               "fixed_operational_cost": 10000,
+               "variable_operational_cost": 5000,
+               "fixed_maintenance_cost": 2000,
+               "variable_maintenance_cost": 1000,
+               "annualized_capex": 18000,
+               "eac": 36000,
+               "npv": 420000,
+               "tco": 700000,
+               "lcoe": 42.0,       # EUR/MWh — None for non-producing assets
+           },
+           ...
+       },
    }
 
-- **Costs**: CAPEX and OPEX are broken down by asset category (Production, Transport, Storage, Conversion, Consumption, and All). NPV is the total lifecycle cost in today's money. LCOE is the average cost per MWh over the system lifetime.
+- **Financials**: Top-level category for all monetary KPIs. This includes cost breakdowns such as CAPEX and OPEX by asset category (Production, Transport, Storage, Conversion, Consumption, and All), as well as derived financial indicators (NPV, LCOE, EAC, TCO). All values are sums over assets.
 - **Energy**: System-wide totals in Joules. Efficiency is the ratio of consumption to production (0 to 1).
 - **Emissions**: Total CO2-equivalent emissions in tonnes and emissions intensity in kg CO2e per MWh of energy consumed.
+- **Asset financials**: Per-asset breakdown of all financial KPIs, keyed by asset ID. System totals in ``"financials"`` are derived by summing these values. ``lcoe`` is ``None`` for non-producing assets (consumers, transport, storage, conversion).
 
 For a detailed explanation of what each KPI means and how to interpret it, see :doc:`user_documentation/kpi_guide`.
 

--- a/doc/user_documentation/kpi_guide.rst
+++ b/doc/user_documentation/kpi_guide.rst
@@ -207,7 +207,7 @@ Undiscounted sum of all costs over the system lifetime, in EUR. Unlike NPV, futu
 
 The replacement factor counts the number of full asset purchases needed to keep the system operational over its lifetime (e.g. 2 for a 30-year system with a 15-year asset). This is the financially exact count and is consistent with the CAPEX replacement logic in NPV.
 
-Pass ``mesido_compatible=True`` to ``CostCalculator.calculate_tco()`` to use the continuous factor ``max(1, system_lifetime / technical_lifetime)`` instead. MESIDO's ``MinimizeTCO`` goal uses this approximation to keep the optimizer objective smooth and differentiable. Use this only when comparing output against MESIDO results.
+Pass ``round_up_replacement=False`` to ``FinancialCalculator.calculate_tco()`` to use the continuous factor ``max(1, system_lifetime / technical_lifetime)`` instead. MESIDO's ``MinimizeTCO`` goal uses this approximation to keep the optimizer objective smooth and differentiable. Use this only when comparing output against MESIDO results.
 
 TCO is always greater than or equal to NPV at any positive discount rate — discounting makes future costs smaller, so the undiscounted sum is always higher. Use TCO when you want to verify optimizer results from MESIDO, or when comparing total expenditure without assuming a particular cost of capital.
 

--- a/doc/user_documentation/kpi_guide.rst
+++ b/doc/user_documentation/kpi_guide.rst
@@ -67,6 +67,8 @@ KPI Summary
 
 Cost breakdowns use the categories **Production**, **Consumption**, **Storage**, **Transport**, **Conversion**, and **All**. For the full return structure and example values, see the :ref:`results-structure` section in the Getting Started guide.
 
+Per-asset financial KPIs are available under the ``asset_financials`` key in the results dict. See `Per-asset Financial KPIs`_ below.
+
 Cost KPIs
 ---------
 
@@ -207,7 +209,10 @@ Undiscounted sum of all costs over the system lifetime, in EUR. Unlike NPV, futu
 
 The replacement factor counts the number of full asset purchases needed to keep the system operational over its lifetime (e.g. 2 for a 30-year system with a 15-year asset). This is the financially exact count and is consistent with the CAPEX replacement logic in NPV.
 
-Pass ``round_up_replacement=False`` to ``FinancialCalculator.calculate_tco()`` to use the continuous factor ``max(1, system_lifetime / technical_lifetime)`` instead. MESIDO's ``MinimizeTCO`` goal uses this approximation to keep the optimizer objective smooth and differentiable. Use this only when comparing output against MESIDO results.
+Pass ``round_up_replacement=False`` to ``calculate_all_kpis()`` to use the continuous factor ``max(1, system_lifetime / technical_lifetime)`` instead. MESIDO's ``MinimizeTCO`` goal uses this approximation to keep the optimizer objective smooth and differentiable. Use this only when comparing output against MESIDO results.
+
+.. note::
+   MESIDO's ``MinimizeTCO`` covers variable and fixed operational costs only — it excludes maintenance costs. TCO values from this calculator will therefore be higher than MESIDO's when maintenance costs are non-zero.
 
 TCO is always greater than or equal to NPV at any positive discount rate — discounting makes future costs smaller, so the undiscounted sum is always higher. Use TCO when you want to verify optimizer results from MESIDO, or when comparing total expenditure without assuming a particular cost of capital.
 
@@ -281,6 +286,60 @@ Common values:
 
 The EU 2030 target for heating is below 100 kg CO2e/MWh. Use this metric to compare the environmental performance of different designs.
 
+.. _per-asset-financial-kpis:
+
+Per-asset Financial KPIs
+------------------------
+
+The ``asset_financials`` key in the results dict contains a breakdown of all financial KPIs for every asset in the system, keyed by asset ID. The system-level totals in ``results["financials"]`` are derived by summing across these per-asset values.
+
+Each entry contains:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 15 55
+
+   * - Field
+     - Unit
+     - Description
+   * - ``investment_cost``
+     - EUR
+     - Upfront capital cost of the asset
+   * - ``installation_cost``
+     - EUR
+     - Installation cost of the asset
+   * - ``fixed_operational_cost``
+     - EUR/yr
+     - Annual fixed operational cost
+   * - ``variable_operational_cost``
+     - EUR/yr
+     - Annual variable operational cost (scales with energy use)
+   * - ``fixed_maintenance_cost``
+     - EUR/yr
+     - Annual fixed maintenance cost
+   * - ``variable_maintenance_cost``
+     - EUR/yr
+     - Annual variable maintenance cost (scales with energy use)
+   * - ``annualized_capex``
+     - EUR/yr
+     - CAPEX spread over the asset's technical lifetime using the annuity formula
+   * - ``eac``
+     - EUR/yr
+     - Equivalent Annual Cost: ``annualized_capex`` + total annual OPEX for this asset
+   * - ``npv``
+     - EUR
+     - Lifecycle cost of this asset in today's money (discounted CAPEX + OPEX)
+   * - ``tco``
+     - EUR
+     - Undiscounted total spend on this asset over the system lifetime
+   * - ``lcoe``
+     - EUR/MWh
+     - Cost per MWh produced by this asset; ``None`` for non-producing assets
+
+For full field semantics — including per-asset discount rate override, LCOE ``None``
+conditions, geothermal COP adjustment, and how system totals relate to per-asset values
+— see the ``AssetFinancialResult`` docstring in the API reference.
+
 Comparing Designs
 -----------------
 
@@ -348,4 +407,6 @@ Limitations
 
 **Static emission factors:** Emission factors are constant over the analysis period — they don't account for grid decarbonization over time. They also exclude embodied carbon in equipment manufacturing and installation.
 
-**System-level results only:** All KPIs are system-wide aggregates. Asset-level and area-level breakdowns are not currently implemented.
+**Asset-level LCOE requires time series:** Per-asset LCOE is ``None`` for assets that do not produce energy (consumers, transport, storage, conversion) and for producing assets that have no time series data (energy would be zero, making LCOE undefined).
+
+**Area-level breakdowns not implemented:** KPIs are available at the system level and per individual asset only.

--- a/doc/user_documentation/kpi_guide.rst
+++ b/doc/user_documentation/kpi_guide.rst
@@ -32,6 +32,14 @@ KPI Summary
      - EUR/MWh
      - €30-80
      - Cost-effectiveness ranking
+   * - EAC
+     - EUR/year
+     - Project-specific
+     - Per-asset annualized cost; annual budget comparison across different asset lifetimes
+   * - TCO
+     - EUR
+     - Project-specific
+     - Undiscounted lifecycle cost; comparable to MESIDO optimizer output
    * - Consumption
      - Joules
      - Demand-driven
@@ -100,14 +108,17 @@ Total lifecycle cost in today's money, accounting for the time value of future e
    r = discount_rate / 100
 
    CAPEX_npv = Sum over assets of:
-       (investment + installation) × Sum over replacements n=0,1,...:
-           1 / (1 + r) ^ (technical_lifetime × n)
+       (investment + installation) × Sum over replacements k=0,1,...,ceil(lifetime/TL)-1:
+           1 / (1 + r) ^ (technical_lifetime × k)
+
+   Let N = floor(system_lifetime), f = system_lifetime - N
 
    OPEX_npv = Sum over assets of:
-       annual_opex × Sum over years t=0..system_lifetime-1:
-           1 / (1 + r) ^ t
+       annual_opex × (Sum t=1..N of 1/(1+r)^t  +  f/(1+r)^(N+1))
 
    NPV = CAPEX_npv + OPEX_npv
+
+CAPEX is paid at the start of each replacement cycle (start-of-period). OPEX follows the standard engineering economics end-of-period convention — costs incurred at the end of each year are discounted accordingly. A fractional final year is prorated linearly.
 
 When an asset's technical lifetime is shorter than the system lifetime, the CAPEX term includes replacement costs — each replacement is discounted to its installation year. For example, an asset with a 15-year technical lifetime in a 30-year analysis has two replacement events, each discounted further into the future.
 
@@ -118,14 +129,15 @@ NPV captures the full cost picture: a system with high CAPEX but low OPEX can ha
 LCOE (Levelized Cost of Energy)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Average cost per MWh of energy delivered over the system lifetime, in EUR/MWh. Energy delivered is discounted using the same discount rate and lifetime as for NPV, so costs and energy are on a consistent present-value basis. This is the most useful metric for comparing designs of different sizes and technologies.
+Average cost per MWh of energy delivered over the system lifetime, in EUR/MWh. Energy is discounted using the same end-of-period convention and parameters as NPV OPEX, so costs and energy are on a consistent present-value basis. This is the most useful metric for comparing designs of different sizes and technologies.
 
 .. code-block:: text
 
    r = discount_rate / 100
 
-   Discounted_Energy = Sum over years t=0..system_lifetime-1:
-       annual_energy_MWh / (1 + r) ^ t
+   Let N = floor(system_lifetime), f = system_lifetime - N
+
+   Discounted_Energy = Sum t=1..N of annual_energy_MWh/(1+r)^t  +  f×annual_energy_MWh/(1+r)^(N+1)
 
    LCOE [EUR/MWh] = NPV [EUR] / Discounted_Energy [MWh]
 
@@ -136,6 +148,68 @@ Typical benchmarks:
 - District heating: €30-50/MWh
 
 Lower LCOE means more cost-effective, but the cheapest option may not meet emission targets.
+
+EAC (Equivalent Annual Cost)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sum of per-asset annualized costs, in EUR/year. Each asset's CAPEX is spread over its
+own technical lifetime using the annuity formula; OPEX is already annual and is added
+directly.
+
+.. code-block:: text
+
+   For each asset:
+       r   = asset discount_rate / 100  (from ESDL, or system default)
+       TL  = asset technical_lifetime
+
+       annualized_CAPEX = (investment + installation) × r / (1 - (1 + r) ^ -TL)
+
+       Special case (r = 0):
+       annualized_CAPEX = (investment + installation) / TL
+
+       annualized_OPEX = annual_opex  (fixed + variable operational + maintenance)
+
+   EAC = Sum over assets of (annualized_CAPEX + annualized_OPEX)
+
+The annuity formula is identical to ``calculate_annuity_factor`` in the MESIDO
+optimizer (``financial_mixin.py``).
+
+**Replacement assumption:** the annuity spreads one asset purchase over its technical
+lifetime, implicitly assuming the asset is always replaced when it reaches end of life.
+The annual charge is therefore the same regardless of how many replacements occur within
+the system lifetime — a pipe with a 40-year lifetime and a heat pump with a 15-year
+lifetime each carry their own constant annual charge. This avoids the need to count
+replacement cycles explicitly and makes EAC independent of ``system_lifetime``.
+
+The implication is that EAC does not account for salvage value at the end of the system
+lifetime. If an asset is replaced partway through the final cycle, the unused residual
+life is not credited. For long system lifetimes relative to asset lifetimes this effect
+is small; for short system lifetimes it may be material.
+
+Use EAC when you need to answer: *"What does this system cost per year, on average?"*
+It is particularly useful when comparing designs with assets of different technical
+lifetimes — NPV alone can be misleading because a longer-lived system accumulates more
+discounted cost even if it is cheaper per year.
+
+TCO (Total Cost of Ownership)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Undiscounted sum of all costs over the system lifetime, in EUR. Unlike NPV, future costs are not discounted to present value — each euro spent in year 25 counts the same as a euro spent today.
+
+.. code-block:: text
+
+   For each asset:
+       replacement_factor = ceil(system_lifetime / technical_lifetime)
+       CAPEX_tco = (investment + installation) × replacement_factor
+       OPEX_tco  = annual_opex × system_lifetime
+
+   TCO = Sum over all assets of (CAPEX_tco + OPEX_tco)
+
+The replacement factor counts the number of full asset purchases needed to keep the system operational over its lifetime (e.g. 2 for a 30-year system with a 15-year asset). This is the financially exact count and is consistent with the CAPEX replacement logic in NPV.
+
+Pass ``mesido_compatible=True`` to ``CostCalculator.calculate_tco()`` to use the continuous factor ``max(1, system_lifetime / technical_lifetime)`` instead. MESIDO's ``MinimizeTCO`` goal uses this approximation to keep the optimizer objective smooth and differentiable. Use this only when comparing output against MESIDO results.
+
+TCO is always greater than or equal to NPV at any positive discount rate — discounting makes future costs smaller, so the undiscounted sum is always higher. Use TCO when you want to verify optimizer results from MESIDO, or when comparing total expenditure without assuming a particular cost of capital.
 
 Energy KPIs
 -----------
@@ -231,6 +305,14 @@ Here's an example of how KPIs can inform a design decision:
      - €1.05M
      - €750k
      - €600k
+   * - EAC (30yr, 5%)
+     - €68k/yr
+     - €49k/yr
+     - €39k/yr
+   * - TCO (30yr)
+     - €1.45M
+     - €1.30M
+     - €1.45M
    * - LCOE
      - €52/MWh
      - €48/MWh
@@ -242,6 +324,8 @@ Here's an example of how KPIs can inform a design decision:
 
 The gas boiler is cheapest to build but most expensive over its lifetime. District heating requires the largest upfront investment but has the lowest lifecycle cost and emissions. The heat pump sits in between on every metric.
 
+EAC makes the annual budget impact explicit: district heating costs €39k/year on average, versus €68k for gas. TCO shows the undiscounted total spend — useful for verifying against MESIDO optimizer output.
+
 Which option is "best" depends on priorities: budget constraints, long-term cost targets, or climate compliance requirements.
 
 Key Assumptions
@@ -249,9 +333,9 @@ Key Assumptions
 
 These defaults affect all calculations. Understanding them helps interpret results and compare scenarios.
 
-**System lifetime:** 30 years. Standard for energy infrastructure. Override with ``system_lifetime=25`` in ``calculate_kpis()``.
+**System lifetime:** 30 years. Standard for energy infrastructure. Override with ``system_lifetime=25`` in ``calculate_all_kpis()``.
 
-**Discount rate:** 5%. Represents the cost of capital for energy infrastructure. Not currently overridable through the public API.
+**Discount rate:** 5%. Represents the cost of capital for energy infrastructure. Override with ``discount_rate=3`` in ``calculate_all_kpis()``.
 
 **Technical lifetime per asset:** 40 years if not specified in ESDL. Real values vary widely — pipes last 40-50 years, heat pumps 15-20.
 

--- a/doc/user_documentation/kpi_guide.rst
+++ b/doc/user_documentation/kpi_guide.rst
@@ -242,7 +242,9 @@ Ratio of energy consumed to energy produced (0 to 1):
 
 Typical values range from 0.80-0.95 for district heating — higher for compact urban networks, lower for long-distance systems. An efficiency above 0.98 is suspiciously high and usually means distribution losses are not being captured.
 
-Without time series data, both consumption and production are zero, making efficiency undefined (returned as 0.0). Time series data is required for meaningful efficiency values.
+Without time series data, both consumption and production are zero, making efficiency
+undefined. In this case the **Energy efficiency** KPI element is omitted from the ESDL
+output entirely. Time series data is required for meaningful efficiency values.
 
 Emission KPIs
 -------------
@@ -261,7 +263,12 @@ Total greenhouse gas emissions from system operation, in tonnes CO2e per year.
 
    Total_Emissions [t CO2e/yr] = Sum of asset emissions [kg] / 1000 [kg/t]
 
-Emission factors are read from the ESDL carrier definitions in **kg CO2e/GJ** (the standard ESDL unit) and converted to kg CO2e/J during loading. The calculator multiplies directly by energy in Joules and emissions from kg to tonnes internally. Emission factors cover upstream emissions (fuel extraction and processing). Benchmarks for 100 households:
+Emission factors are read from the ESDL carrier definitions in **kg CO2e/GJ** (the standard
+ESDL unit) and converted to kg CO2e/J during loading. Only ``EnergyCarrier`` objects carry an
+emission attribute; heat network assets that use ``HeatCommodity`` carriers have no emission
+factor and contribute ``0.0`` to the total (a DEBUG message is logged for each such asset).
+The calculator multiplies directly by energy in Joules and converts kg to tonnes internally.
+Emission factors cover upstream emissions (fuel extraction and processing). Benchmarks for 100 households:
 
 - Gas heating: 80-120 t CO2e/year
 - Heat pump on grid electricity: 20-40 t CO2e/year

--- a/doc/user_documentation/kpi_reference.rst
+++ b/doc/user_documentation/kpi_reference.rst
@@ -130,4 +130,6 @@ The calculator accepts cost values in the units specified in the ESDL ``costInfo
    * - ``EUR/MWh``
      - value x annual energy (J) x 2.78e-10
 
+**Geothermal COP adjustment:** For geothermal assets with a COP (Coefficient of Performance) greater than zero, variable operational and maintenance costs in ``EUR/kWh`` or ``EUR/MWh`` are applied to ``energy / COP`` rather than ``energy`` directly. This reflects that geothermal plants deliver more heat than they consume as input energy.
+
 If a cost field uses a unit not listed above, the cost is ignored and a WARNING is logged with the asset name and the unsupported unit string. Check the log output when cost KPIs seem unexpectedly low.

--- a/doc/user_documentation/kpi_reference.rst
+++ b/doc/user_documentation/kpi_reference.rst
@@ -19,10 +19,12 @@ The calculators search for time series data on each asset using specific key nam
      - Keys searched (in order)
    * - Consumption
      - Consumer
-     - ``ThermalConsumption``, ``Consumption``, ``Energy``
+     - ``ThermalConsumption``, ``Consumption``, ``Energy``,
+       ``heat_power_primary`` *(simulator-core: primary side of heat pump / heat exchanger)*
    * - Production
      - Producer, Geothermal
-     - ``ThermalProduction``, ``Production``, ``heat_supplied``, ``Energy``
+     - ``ThermalProduction``, ``Production``, ``heat_supplied``, ``Energy``,
+       ``heat_power_secondary`` *(simulator-core: secondary side of heat pump / heat exchanger)*
    * - Demand
      - Consumer
      - ``ThermalDemand``, ``Demand``, ``heat_demand`` (falls back to consumption keys)
@@ -37,16 +39,24 @@ The calculators search for time series data on each asset using specific key nam
      - Keys searched (in order)
      - Notes
    * - Producer, Geothermal
-     - ``ThermalProduction``, ``Production``, ``heat_supplied``, ``Energy``
-     - Same as energy production
+     - ``ThermalProduction``, ``Production``, ``heat_supplied``, ``Energy``,
+       ``heat_power_secondary``
+     - Same keys as energy production
    * - Consumer
-     - ``ThermalConsumption``, ``Consumption``, ``Energy``
-     - Same as energy consumption
+     - ``ThermalConsumption``, ``Consumption``, ``Energy``,
+       ``heat_power_primary``
+     - Same keys as energy consumption
    * - Conversion
-     - ``ElectricalConsumption``, ``ThermalProduction``
-     - Only used for emission calculation
+     - ``ElectricalConsumption``, ``electricity_consumption``, ``ThermalProduction``
+     - Only used for emission calculation. ``electricity_consumption`` is the
+       field name used by simulator-core for heat pump assets.
 
 Time series values are in Watts (power). The calculator integrates over the time step to get energy in Joules and annualizes based on the series duration. If no matching key is found, the asset contributes zero to that metric (logged at DEBUG level). If the time series has a non-positive duration (``time_step × number_of_values ≤ 0``), the asset is skipped with a WARNING log.
+
+KPI elements whose computed value is zero — because no matching time series or cost attributes
+were found — are **omitted entirely** from the ESDL output rather than written as zero-value
+elements. This is consistent with mesido's behavior and avoids pyESDL's serialization quirk
+where ``float(0.0)`` is emitted as a ``<stringItem>`` with no ``value`` attribute.
 
 **Cost calculator:** Variable operational and maintenance costs in ``EUR/kWh`` or ``EUR/MWh`` use the **first** time series available on the asset (regardless of key name). For geothermal assets with COP > 0, the energy is divided by COP before applying the cost rate.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ dependencies = [
     "types-xmltodict", # Type stubs for xmltodict
     "influxdb>=5.3.2",
     "pydantic>=2.0.0,<3.0", # Modern data validation with type hints
-    "urllib3>=2.6.3", # Security: CVE fixes in 2.6.3+
-    "filelock>=3.20.1", # Security: CVE fixes in 3.20.1+
+    "urllib3>=2.6.3", # Security: CVE fixes
+    "filelock>=3.25.0", # Security: CVE fixes
 ]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "coloredlogs~=15.0.1",
     "numpy>=2.1.0,<3.0", # Compatible with simulator-worker
     "pandas>=2.2.2,<3.0", # Requires pandas >=2.2.2 for numpy 2.x compatibility
-    "pandas-stubs", # Type stubs for pandas
     "pyesdl~=25.7", # Compatible with simulator-worker
     "xmltodict==0.14.2",
-    "types-xmltodict", # Type stubs for xmltodict
     "influxdb>=5.3.2",
     "pydantic>=2.0.0,<3.0", # Modern data validation with type hints
     "urllib3>=2.6.3", # Security: CVE fixes
@@ -46,12 +43,12 @@ lint = [
     "ruff>=0.6.0",
     "mypy ~= 1.5.1",
     "pre-commit ~= 3.6.0",
+    "pandas-stubs", # Type stubs for pandas
+    "types-xmltodict", # Type stubs for xmltodict
 ]
 analysis = [
     "codespell>=2.0.0",    # Spell checking
     "vulture>=2.0.0",      # Dead code detection
-    "bandit>=1.7.0",       # Security vulnerability scanner
-    "radon>=6.0.0",        # Code complexity analysis
     "pylint>=3.0.0",       # Duplicate code detection (run with --disable=all --enable=similarities)
     "pipdeptree>=2.0.0",   # Dependency analysis and visualization
     "pip-audit>=2.0.0",    # Official Python package vulnerability scanner
@@ -176,7 +173,7 @@ exclude = ['.venv/*', 'venv/*', 'doc/*', 'ci/*']
 
 # mypy per-module options:
 [[tool.mypy.overrides]]
-module = ["unit_test.*", "coloredlogs.*", "pandas.*", "xmltodict.*", "esdl.*", "esdl.esdl_handler.*", "jinja2.*"]
+module = ["unit_test.*", "pandas.*", "xmltodict.*", "esdl.*", "esdl.esdl_handler.*", "jinja2.*"]
 check_untyped_defs = true
 ignore_missing_imports = true
 

--- a/src/kpicalculator/__init__.py
+++ b/src/kpicalculator/__init__.py
@@ -15,6 +15,16 @@
 
 """KPI Calculator package for energy systems.
 
+The main entry points are :func:`calculate_kpis` and :class:`KpiManager`.
+Both return a :class:`KpiResults` dict. The following types are exported for
+use in type annotations:
+
+- :class:`KpiResults` — top-level results dict
+- :class:`FinancialResults` — ``results["financials"]``
+- :class:`EnergyResults` — ``results["energy"]``
+- :class:`EmissionResults` — ``results["emissions"]``
+- :class:`AssetFinancialResult` — ``results["asset_financials"]["<asset_id>"]``
+
 Default parameter values for callers that need to resolve absent config:
 
 - :data:`DEFAULT_SYSTEM_LIFETIME_YEARS` — 30.0
@@ -39,22 +49,34 @@ from .exceptions import (
     SecurityError,
     ValidationError,
 )
-from .kpi_manager import KpiManager
+from .kpi_manager import (
+    AssetFinancialResult,
+    EmissionResults,
+    EnergyResults,
+    FinancialResults,
+    KpiManager,
+    KpiResults,
+)
 from .security import ConfigFileCredentialManager, SecureCredentialManager
 
 __all__ = [
     "DEFAULT_DISCOUNT_RATE_PERCENT",
     "DEFAULT_SYSTEM_LIFETIME_YEARS",
     "Asset",
+    "AssetFinancialResult",
     "AssetType",
     "CalculationError",
     "ConfigFileCredentialManager",
     "CredentialError",
     "DataSourceError",
     "DatabaseError",
+    "EmissionResults",
+    "EnergyResults",
     "EnergySystem",
+    "FinancialResults",
     "KpiCalculatorError",
     "KpiManager",
+    "KpiResults",
     "SecureCredentialManager",
     "SecurityError",
     "TimeSeries",

--- a/src/kpicalculator/__init__.py
+++ b/src/kpicalculator/__init__.py
@@ -98,7 +98,7 @@ def main() -> None:
         # This should write KPI results back to the ESDL file or create a new one
         logger = logging.getLogger(__name__)
         logger.info("KPI calculation completed successfully")
-        logger.info(f"Total CAPEX: {results['costs']['capex']['All']:.2f} EUR")
+        logger.info(f"Total CAPEX: {results['financials']['capex']['All']:.2f} EUR")
         logger.info(f"Total emissions: {results['emissions']['total']:.3f} tons CO2")
         logger.info(f"Energy consumption: {results['energy']['consumption']:.0f} J")
 

--- a/src/kpicalculator/__init__.py
+++ b/src/kpicalculator/__init__.py
@@ -15,9 +15,10 @@
 
 """KPI Calculator package for energy systems.
 
-The main entry points are :func:`calculate_kpis` and :class:`KpiManager`.
-Both return a :class:`KpiResults` dict. The following types are exported for
-use in type annotations:
+The main entry points are :func:`calculate_kpis`, :func:`calculate_kpis_from_simulator`,
+and :class:`KpiManager`. To embed results back into an ESDL string, use
+:func:`build_esdl_string_with_kpis`. All ``calculate_kpis_from_*`` functions return a
+:class:`KpiResults` dict. The following types are exported for use in type annotations:
 
 - :class:`KpiResults` — top-level results dict
 - :class:`FinancialResults` — ``results["financials"]``
@@ -38,7 +39,7 @@ import sys
 from pathlib import Path
 
 from .adapters.common_model import Asset, AssetType, EnergySystem, TimeSeries
-from .api import calculate_kpis
+from .api import build_esdl_string_with_kpis, calculate_kpis, calculate_kpis_from_simulator
 from .common.constants import DEFAULT_DISCOUNT_RATE_PERCENT, DEFAULT_SYSTEM_LIFETIME_YEARS
 from .exceptions import (
     CalculationError,
@@ -81,7 +82,9 @@ __all__ = [
     "SecurityError",
     "TimeSeries",
     "ValidationError",
+    "build_esdl_string_with_kpis",
     "calculate_kpis",
+    "calculate_kpis_from_simulator",
 ]
 
 # Version information

--- a/src/kpicalculator/adapters/common_model.py
+++ b/src/kpicalculator/adapters/common_model.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from esdl import esdl
 
-from ..common.constants import DEFAULT_DISCOUNT_RATE_PERCENT, DEFAULT_TECHNICAL_LIFETIME_YEARS
+from ..common.constants import DEFAULT_TECHNICAL_LIFETIME_YEARS
 
 
 class AssetType(Enum):
@@ -55,8 +55,10 @@ class Asset:
     variable_maintenance_cost_unit: str = "EUR/MWh"
 
     # Lifecycle properties
+    # discount_rate is None when not set in ESDL costInformation; calculate_eac
+    # then falls back to its discount_rate parameter.
     technical_lifetime: float = DEFAULT_TECHNICAL_LIFETIME_YEARS  # years
-    discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT  # %
+    discount_rate: float | None = None  # %
     emission_factor: float = 0.0  # kg/J (converted from ESDL kg/GJ by adapter)
 
     # Aggregation

--- a/src/kpicalculator/adapters/esdl_adapter.py
+++ b/src/kpicalculator/adapters/esdl_adapter.py
@@ -578,6 +578,30 @@ class EsdlAdapter(BaseAdapter):
 
         cost_info = esdl_asset.costInformation
 
+        # Extract per-asset discount rate (percentage, e.g. 5 for 5%).
+        # The ESDL schema stores discountRate as a plain float with no embedded unit.
+        # Values outside [0, 100] are rejected. Values in (0, 1) likely indicate a
+        # ratio (e.g. 0.05 instead of 5) and are warned about but stored as-is.
+        if hasattr(cost_info, "discountRate") and cost_info.discountRate is not None:
+            raw_rate = float(cost_info.discountRate)
+            if raw_rate < 0 or raw_rate > 100:
+                self.logger.warning(
+                    "Asset '%s' has discountRate=%s outside [0, 100]. "
+                    "Expected a percentage (e.g. 5 for 5%%). Skipping.",
+                    esdl_asset.name,
+                    raw_rate,
+                )
+            else:
+                if 0 < raw_rate < 1:
+                    self.logger.warning(
+                        "Asset '%s' has discountRate=%s which looks like a ratio "
+                        "rather than a percentage. Expected e.g. 5 for 5%%. "
+                        "Storing as-is; verify the ESDL source.",
+                        esdl_asset.name,
+                        raw_rate,
+                    )
+                costs["discount_rate"] = raw_rate
+
         # Mapping of ESDL cost fields to asset dict keys
         cost_mappings = {
             "investmentCosts": ("investment_cost", "investment_cost_unit"),

--- a/src/kpicalculator/adapters/esdl_adapter.py
+++ b/src/kpicalculator/adapters/esdl_adapter.py
@@ -541,11 +541,18 @@ class EsdlAdapter(BaseAdapter):
     def _get_emission_factor(self, esdl_element: esdl.Asset) -> float:
         """Get the emission factor of an ESDL element.
 
+        Reads the emission factor from the first port whose carrier is an ``EnergyCarrier``.
+        If the carrier is any other type (e.g. ``HeatCommodity``, which has no ``.emission``
+        attribute), the factor is treated as ``0.0`` and a DEBUG message is logged — the asset
+        will not contribute to total emissions. This is the expected behavior for heat network
+        assets that use heat commodities.
+
         Args:
             esdl_element: ESDL element
 
         Returns:
-            Emission factor in kg/J (converted from ESDL kg/GJ via division by 1e9)
+            Emission factor in kg/J (converted from ESDL kg/GJ via division by 1e9),
+            or 0.0 if no ``EnergyCarrier`` port is found.
         """
         # Uses ESDL carrier emission factors (in kg/GJ)
         # Converts to kg/J for use in emission calculations
@@ -555,6 +562,15 @@ class EsdlAdapter(BaseAdapter):
             if port.carrier is not None:
                 if isinstance(port.carrier, esdl.EnergyCarrier):
                     return float(port.carrier.emission) / 1e9  # kg/GJ → kg/J
+                # HeatCommodity and other carrier types have no .emission attribute.
+                # Treat as zero-emission with a debug log so callers can detect the gap.
+                self.logger.debug(
+                    "Carrier '%s' on asset '%s' is not an EnergyCarrier (type: %s). "
+                    "Emission factor set to 0.0.",
+                    getattr(port.carrier, "name", "<unnamed>"),
+                    esdl_element.name,
+                    type(port.carrier).__name__,
+                )
                 return 0.0
         return 0.0
 

--- a/src/kpicalculator/api.py
+++ b/src/kpicalculator/api.py
@@ -30,6 +30,7 @@ def calculate_kpis(
     time_series: str | Path | None = None,
     timeseries_dataframes: dict[str, pd.DataFrame] | None = None,
     system_lifetime: float = DEFAULT_SYSTEM_LIFETIME_YEARS,
+    round_up_replacement: bool = True,
 ) -> KpiResults:
     """Calculate KPIs from ESDL files with supporting data.
 
@@ -48,6 +49,10 @@ def calculate_kpis(
             with time-indexed energy/power data. When provided, takes precedence
             over database loading and time_series file parameter.
         system_lifetime: System lifetime in years
+        round_up_replacement: If True (default), NPV, LCOE, and TCO use ``ceil``
+            for the asset replacement count (financially exact). If False, uses the
+            continuous factor ``max(1, n / technical_lifetime)`` for optimizer
+            compatibility.
 
     Returns:
         KpiResults containing calculated KPIs
@@ -74,7 +79,10 @@ def calculate_kpis(
         )
 
         logger.info("Calculating KPIs...")
-        results = kpi_manager.calculate_all_kpis(system_lifetime=system_lifetime)
+        results = kpi_manager.calculate_all_kpis(
+            system_lifetime=system_lifetime,
+            round_up_replacement=round_up_replacement,
+        )
         logger.info("KPI calculation completed successfully")
 
         return results

--- a/src/kpicalculator/api.py
+++ b/src/kpicalculator/api.py
@@ -13,16 +13,29 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Public API for KPI Calculator library."""
+"""Public API for KPI Calculator library.
+
+Entry points by data source:
+
+- :func:`calculate_kpis` — ESDL file + optional time series file or DataFrames
+- :func:`calculate_kpis_from_simulator` — OMOTES simulator DataFrame + ESDL string
+
+Embedding:
+
+- :func:`build_esdl_string_with_kpis` — write any :class:`KpiResults` into an ESDL string;
+  data-source-agnostic, usable after any ``calculate_kpis_from_*`` call.
+"""
 
 import logging
 from pathlib import Path
 
 import pandas as pd
 
-from .common.constants import DEFAULT_SYSTEM_LIFETIME_YEARS
+from .common.constants import DEFAULT_DISCOUNT_RATE_PERCENT, DEFAULT_SYSTEM_LIFETIME_YEARS
 from .exceptions import KpiCalculatorError
 from .kpi_manager import KpiManager, KpiResults
+
+_logger = logging.getLogger(__name__)
 
 
 def calculate_kpis(
@@ -30,45 +43,42 @@ def calculate_kpis(
     time_series: str | Path | None = None,
     timeseries_dataframes: dict[str, pd.DataFrame] | None = None,
     system_lifetime: float = DEFAULT_SYSTEM_LIFETIME_YEARS,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT,
     round_up_replacement: bool = True,
 ) -> KpiResults:
-    """Calculate KPIs from ESDL files with supporting data.
+    """Calculate KPIs from an ESDL file with optional time series data.
 
-    This is the main library function that can be called programmatically.
-    Supports both traditional file-based time series and pandas DataFrames
-    for simulator-worker integration.
-
-    Cost data is extracted from ESDL costInformation elements. Cost unit
+    Cost data is extracted from ESDL ``costInformation`` elements. Cost unit
     conversion factors (EUR/kW, EUR/MW, etc.) are built-in; see
     ``kpicalculator.common.constants.COST_UNIT_FACTORS`` for the full list.
 
     Args:
-        esdl_file: Path to ESDL file
-        time_series: Optional path to time series XML (when timeseries_dataframes not provided)
-        timeseries_dataframes: Optional dict mapping asset IDs to pandas DataFrames
-            with time-indexed energy/power data. When provided, takes precedence
-            over database loading and time_series file parameter.
-        system_lifetime: System lifetime in years
-        round_up_replacement: If True (default), NPV, LCOE, and TCO use ``ceil``
-            for the asset replacement count (financially exact). If False, uses the
-            continuous factor ``max(1, n / technical_lifetime)`` for optimizer
-            compatibility.
+        esdl_file: Path to ESDL file.
+        time_series: Optional path to time series XML (when
+            ``timeseries_dataframes`` not provided).
+        timeseries_dataframes: Optional dict mapping asset IDs to pandas
+            DataFrames with time-indexed energy/power data. Takes precedence
+            over ``time_series`` when provided.
+        system_lifetime: System lifetime in years.
+            Default: ``DEFAULT_SYSTEM_LIFETIME_YEARS``.
+        discount_rate: System-wide fallback discount rate in percent.
+            Default: ``DEFAULT_DISCOUNT_RATE_PERCENT``.
+        round_up_replacement: If True (default), NPV, LCOE, and TCO use
+            ``ceil`` for the asset replacement count (financially exact).
+            If False, uses the continuous factor
+            ``max(1, n / technical_lifetime)`` for optimizer compatibility.
 
     Returns:
-        KpiResults containing calculated KPIs
+        :class:`KpiResults` containing calculated KPIs.
 
     Raises:
-        KpiCalculatorError: For any calculation or validation errors
+        KpiCalculatorError: For any calculation or validation errors.
     """
-    logger = logging.getLogger(__name__)
-
-    # Validate inputs
     esdl_path = Path(esdl_file)
     if not esdl_path.exists():
         raise KpiCalculatorError(f"ESDL file not found: {esdl_path}")
 
-    logger.info(f"Loading ESDL file: {esdl_path}")
-    logger.info("Extracting costs from ESDL costInformation elements")
+    _logger.info(f"Loading ESDL file: {esdl_path}")
 
     try:
         kpi_manager = KpiManager()
@@ -77,19 +87,94 @@ def calculate_kpis(
             time_series_file=str(time_series) if time_series else None,
             timeseries_dataframes=timeseries_dataframes,
         )
-
-        logger.info("Calculating KPIs...")
-        results = kpi_manager.calculate_all_kpis(
+        return kpi_manager.calculate_all_kpis(
             system_lifetime=system_lifetime,
+            discount_rate=discount_rate,
             round_up_replacement=round_up_replacement,
         )
-        logger.info("KPI calculation completed successfully")
-
-        return results
-
+    except KpiCalculatorError:
+        raise
     except Exception as e:
-        logger.error(f"KPI calculation failed: {e}")
-        # Re-raise as KpiCalculatorError if it isn't already one
-        if isinstance(e, KpiCalculatorError):
-            raise
         raise KpiCalculatorError(f"Calculation failed: {e}") from e
+
+
+def calculate_kpis_from_simulator(
+    simulator_result: pd.DataFrame,
+    esdl_string: str,
+    system_lifetime: float = DEFAULT_SYSTEM_LIFETIME_YEARS,
+    discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT,
+    round_up_replacement: bool = True,
+) -> KpiResults:
+    """Calculate KPIs from OMOTES simulator results.
+
+    Args:
+        simulator_result: DataFrame produced by the simulator, with a
+            ``DatetimeIndex`` and ``(port_id, property_name)`` tuple columns.
+        esdl_string: The input ESDL as an XML string, used to resolve port IDs
+            to their owning assets and to extract cost data.
+        system_lifetime: System lifetime in years.
+            Default: ``DEFAULT_SYSTEM_LIFETIME_YEARS``.
+        discount_rate: System-wide fallback discount rate in percent.
+            Default: ``DEFAULT_DISCOUNT_RATE_PERCENT``.
+        round_up_replacement: If True (default), NPV, LCOE, and TCO use
+            ``ceil`` for the asset replacement count (financially exact).
+            If False, uses the continuous factor
+            ``max(1, n / technical_lifetime)`` for optimizer compatibility.
+
+    Returns:
+        :class:`KpiResults` containing calculated KPIs.
+
+    Raises:
+        KpiCalculatorError: For any calculation or validation errors.
+    """
+    try:
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_simulator(simulator_result, esdl_string)
+        return kpi_manager.calculate_all_kpis(
+            system_lifetime=system_lifetime,
+            discount_rate=discount_rate,
+            round_up_replacement=round_up_replacement,
+        )
+    except KpiCalculatorError:
+        raise
+    except Exception as e:
+        raise KpiCalculatorError(f"Calculation failed: {e}") from e
+
+
+def build_esdl_string_with_kpis(esdl_string: str, kpi_results: KpiResults) -> str:
+    """Embed KPI results into an ESDL XML string and return the updated string.
+
+    Data-source-agnostic: works with results from any ``calculate_kpis_from_*``
+    function. The KPI values are written as ``DistributionKPI`` elements on the
+    main area of the energy system, ready for MapEditor visualisation.
+
+    This is the standalone equivalent of :meth:`KpiManager.build_esdl_string_with_kpis`
+    — use this when you do not hold a ``KpiManager`` instance.
+
+    Args:
+        esdl_string: ESDL XML string to embed KPIs into.
+        kpi_results: KPI results from any ``calculate_kpis_from_*`` call.
+
+    Returns:
+        Updated ESDL XML string with KPIs embedded.
+
+    Raises:
+        KpiCalculatorError: If embedding fails.
+    """
+    from typing import cast
+
+    from esdl.esdl_handler import EnergySystemHandler
+
+    from .reporting.esdl_kpi_exporter import EsdlKpiExporter
+
+    if not esdl_string or not esdl_string.strip():
+        raise KpiCalculatorError("esdl_string must not be empty.")
+    try:
+        esh = EnergySystemHandler()
+        esh.load_from_string(esdl_string)
+        EsdlKpiExporter().export(kpi_results, esh.energy_system, destination=None, level="system")
+        return cast(str, esh.to_string())
+    except KpiCalculatorError:
+        raise
+    except Exception as e:
+        raise KpiCalculatorError(f"Failed to build ESDL string with KPIs: {e}") from e

--- a/src/kpicalculator/calculators/cost_calculator.py
+++ b/src/kpicalculator/calculators/cost_calculator.py
@@ -8,6 +8,7 @@ from ..common.constants import (
     PERCENTAGE_TO_DECIMAL,
     SECONDS_PER_YEAR,
 )
+from ..exceptions import CalculationError
 
 logger = logging.getLogger(__name__)
 
@@ -52,61 +53,254 @@ class CostCalculator:
         return result
 
     def calculate_npv(
-        self, system_lifetime: float, discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT
+        self,
+        system_lifetime: float,
+        discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT,
+        round_up_replacement: bool = True,
     ) -> float:
         """Calculate Net Present Value for the energy system.
 
+        By default (``round_up_replacement=True``) CAPEX uses a start-of-period
+        convention: one discounted payment per replacement cycle, with the number of
+        replacements equal to ``ceil(system_lifetime / technical_lifetime)``.
+        OPEX uses the standard end-of-period convention (``t = 1 … n``). A fractional
+        final year is prorated linearly. See ``kpi_guide.rst`` for the full formula.
+
+        Set ``round_up_replacement=False`` to use the continuous replacement factor
+        ``max(1, system_lifetime / technical_lifetime)`` as a scalar multiplier on a
+        single undiscounted CAPEX — the approximation used by optimizers such as MESIDO.
+
+        Raises:
+            CalculationError: If ``system_lifetime <= 0``, ``discount_rate`` is outside
+                [0, 100], or any asset has a non-positive ``technical_lifetime``.
+
         Args:
-            system_lifetime: System lifetime in years
-            discount_rate: Discount rate in percentage
+            system_lifetime: System lifetime in years. May be fractional.
+            discount_rate: Discount rate in percentage (e.g. 5 for 5%).
+            round_up_replacement: If True (default), use ``ceil`` for the replacement
+                count with per-replacement discounting. If False, use the continuous
+                factor ``max(1, n / technical_lifetime)`` for optimizer compatibility.
 
         Returns:
-            Net Present Value
+            Net Present Value in EUR.
         """
+        if system_lifetime <= 0:
+            raise CalculationError(f"system_lifetime must be positive (got {system_lifetime}).")
+        if discount_rate < 0 or discount_rate > 100:
+            raise CalculationError(
+                f"discount_rate must be between 0 and 100 (got {discount_rate})."
+            )
+
+        discount_rate_ratio = discount_rate * PERCENTAGE_TO_DECIMAL
         npv = 0.0
 
         for asset in self.energy_system.assets:
+            if asset.technical_lifetime <= 0:
+                raise CalculationError(
+                    f"Asset '{asset.name}' has non-positive technical_lifetime "
+                    f"({asset.technical_lifetime}). Cannot compute NPV."
+                )
+
             # Calculate NPV for CAPEX
-            capex_npv = asset.investment_cost + asset.installation_cost
-            capex_npv *= sum(
-                [
-                    1.0
-                    / math.pow(
-                        1.0 + discount_rate * PERCENTAGE_TO_DECIMAL, asset.technical_lifetime * n
-                    )
+            capex = asset.investment_cost + asset.installation_cost
+            if round_up_replacement:
+                capex_npv = capex * sum(
+                    1.0 / math.pow(1.0 + discount_rate_ratio, asset.technical_lifetime * n)
                     for n in range(math.ceil(system_lifetime / asset.technical_lifetime))
-                ]
-            )
+                )
+            else:
+                replacements = max(1.0, system_lifetime / asset.technical_lifetime)
+                capex_npv = capex * replacements
 
             # Calculate NPV for OPEX
+            opex_annual = (
+                self._calculate_fixed_operational_cost(asset)
+                + self._calculate_fixed_maintenance_cost(asset)
+                + self._calculate_variable_operational_cost(asset)
+                + self._calculate_variable_maintenance_cost(asset)
+            )
+
+            # End-of-period convention (standard engineering economics): OPEX at year t
+            # is discounted by (1+r)^t, t = 1..n. Consistent with the annuity formula
+            # in calculate_eac. A fractional final year is prorated linearly.
+            full_years = int(system_lifetime)
+            opex_npv = opex_annual * sum(
+                1.0 / math.pow(1.0 + discount_rate_ratio, t) for t in range(1, full_years + 1)
+            )
+            fraction = system_lifetime - full_years
+            if fraction > 0:
+                opex_npv += (
+                    opex_annual * fraction / math.pow(1.0 + discount_rate_ratio, full_years + 1)
+                )
+
+            npv += capex_npv + opex_npv
+
+        return npv
+
+    def calculate_eac(self, discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT) -> float:
+        """Calculate Equivalent Annual Cost for the energy system.
+
+        Sums per-asset annualized costs using each asset's own ``technical_lifetime``
+        and ``discount_rate`` (from ESDL ``costInformation.discountRate``, falling back
+        to the ``discount_rate`` parameter). The annuity formula spreads one asset
+        purchase over its technical lifetime, implicitly assuming perpetual replacement —
+        the annual charge is the same regardless of how many replacements occur within
+        the system lifetime. OPEX is already annual and is passed through directly.
+
+        This matches the approach used in the MESIDO optimizer
+        (``calculate_annuity_factor`` in ``financial_mixin.py``). See ``kpi_guide.rst``
+        for the formula and a discussion of the replacement assumption.
+
+        Raises:
+            CalculationError: If ``discount_rate`` is outside [0, 100] or any asset
+                has a non-positive ``technical_lifetime``.
+
+        Args:
+            discount_rate: Fallback discount rate in percentage (e.g. 5 for 5%),
+                used when ``asset.discount_rate is None`` (i.e. no
+                ``costInformation.discountRate`` was present in the ESDL for that asset).
+
+        Returns:
+            Equivalent Annual Cost in EUR/year.
+        """
+        if discount_rate < 0 or discount_rate > 100:
+            raise CalculationError(
+                f"discount_rate must be between 0 and 100 (got {discount_rate})."
+            )
+
+        eac = 0.0
+
+        for asset in self.energy_system.assets:
+            if asset.technical_lifetime <= 0:
+                raise CalculationError(
+                    f"Asset '{asset.name}' has non-positive technical_lifetime "
+                    f"({asset.technical_lifetime}). Cannot compute EAC."
+                )
+
+            r = self._get_effective_discount_rate(asset, discount_rate) * PERCENTAGE_TO_DECIMAL
+
+            capex = self._calculate_investment_cost(asset) + self._calculate_installation_cost(
+                asset
+            )
+            if r == 0.0:
+                annualized_capex = capex / asset.technical_lifetime
+            else:
+                annualized_capex = capex * r / (1.0 - math.pow(1.0 + r, -asset.technical_lifetime))
+
+            opex_annual = (
+                self._calculate_fixed_operational_cost(asset)
+                + self._calculate_fixed_maintenance_cost(asset)
+                + self._calculate_variable_operational_cost(asset)
+                + self._calculate_variable_maintenance_cost(asset)
+            )
+
+            eac += annualized_capex + opex_annual
+
+        return eac
+
+    def calculate_tco(self, system_lifetime: float, round_up_replacement: bool = True) -> float:
+        """Calculate Total Cost of Ownership for the energy system.
+
+        Undiscounted sum of all costs over the system lifetime::
+
+            TCO = Sum over assets of:
+                (investment + installation) * replacement_factor
+                + annual_opex * system_lifetime
+
+        By default (``round_up_replacement=True``) the replacement factor is
+        ``ceil(system_lifetime / technical_lifetime)`` — the financially exact count
+        of full asset purchases needed to keep the system operational. This is
+        consistent with ``calculate_npv()``, which uses the same ``ceil`` logic for
+        CAPEX discounting, so ``TCO == NPV`` at ``discount_rate=0``.
+
+        Set ``round_up_replacement=False`` to use the continuous factor
+        ``max(1, system_lifetime / technical_lifetime)`` instead. Optimizers such as
+        MESIDO use this approximation to keep the objective smooth and differentiable.
+        Use this option only when comparing KPI output against optimizer results.
+
+        Note: MESIDO's ``MinimizeTCO`` covers variable and fixed operational costs only.
+        This calculator also includes fixed and variable maintenance costs, so TCO values
+        will differ from MESIDO when maintenance costs are non-zero.
+
+        Raises:
+            CalculationError: If ``system_lifetime <= 0`` or any asset has a non-positive
+                ``technical_lifetime``.
+
+        Args:
+            system_lifetime: System lifetime in years.
+            round_up_replacement: If True (default), use ``ceil`` for the replacement
+                count (financially exact). If False, use the continuous factor
+                ``max(1, n / technical_lifetime)`` for optimizer compatibility.
+
+        Returns:
+            Total Cost of Ownership in EUR.
+        """
+        if system_lifetime <= 0:
+            raise CalculationError(f"system_lifetime must be positive (got {system_lifetime}).")
+
+        tco = 0.0
+
+        for asset in self.energy_system.assets:
+            if asset.technical_lifetime <= 0:
+                raise CalculationError(
+                    f"Asset '{asset.name}' has non-positive technical_lifetime "
+                    f"({asset.technical_lifetime}). Cannot compute TCO."
+                )
+
+            capex = self._calculate_investment_cost(asset) + self._calculate_installation_cost(
+                asset
+            )
+            replacements: float
+            if round_up_replacement:
+                replacements = math.ceil(system_lifetime / asset.technical_lifetime)
+            else:
+                replacements = max(1.0, system_lifetime / asset.technical_lifetime)
+            tco += capex * replacements
+
             opex_annual = (
                 self._calculate_fixed_operational_cost(asset)
                 + self._calculate_variable_operational_cost(asset)
                 + self._calculate_fixed_maintenance_cost(asset)
                 + self._calculate_variable_maintenance_cost(asset)
             )
+            tco += opex_annual * system_lifetime
 
-            opex_npv = opex_annual * sum(
-                1.0 / math.pow(1.0 + discount_rate * PERCENTAGE_TO_DECIMAL, n)
-                for n in range(int(system_lifetime))
-            )
-
-            npv += capex_npv + opex_npv
-
-        return npv
+        return tco
 
     def calculate_lcoe(
-        self, system_lifetime: float, discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT
+        self,
+        system_lifetime: float,
+        discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT,
+        round_up_replacement: bool = True,
     ) -> float:
         """Calculate Levelized Cost of Energy.
 
+        Divides NPV by discounted energy to put costs and energy on the same
+        present-value basis. Energy discounting uses the same end-of-period convention
+        and fractional-year proration as NPV OPEX. See ``kpi_guide.rst`` for the formula.
+
+        The ``round_up_replacement`` flag is passed through to ``calculate_npv``; see
+        that method for its effect on CAPEX replacement counting.
+
+        Returns 0.0 if annual energy consumption is zero or negative.
+
+        Raises:
+            CalculationError: If ``system_lifetime <= 0``, ``discount_rate`` is outside
+                [0, 100], or any asset has a non-positive ``technical_lifetime``.
+
         Args:
-            system_lifetime: System lifetime in years
-            discount_rate: Discount rate in percentage
+            system_lifetime: System lifetime in years. May be fractional.
+            discount_rate: Discount rate in percentage (e.g. 5 for 5%).
+            round_up_replacement: Passed through to ``calculate_npv``. If True (default),
+                use ``ceil`` for the replacement count. If False, use the continuous
+                factor for optimizer compatibility.
 
         Returns:
-            Levelized Cost of Energy in EUR/MWh
+            Levelized Cost of Energy in EUR/MWh.
         """
+        if system_lifetime <= 0:
+            raise CalculationError(f"system_lifetime must be positive (got {system_lifetime}).")
+
         from ..calculators.energy_calculator import EnergyCalculator
 
         energy_calc = EnergyCalculator(self.energy_system)
@@ -117,13 +311,20 @@ class CostCalculator:
         if annual_energy <= 0:
             return 0.0
 
-        npv = self.calculate_npv(system_lifetime, discount_rate)
+        npv = self.calculate_npv(
+            system_lifetime, discount_rate, round_up_replacement=round_up_replacement
+        )
 
-        # Calculate discounted energy production
-        discounted_energy = 0.0
-        for year in range(int(system_lifetime)):
-            discounted_energy += annual_energy / math.pow(
-                1.0 + discount_rate * PERCENTAGE_TO_DECIMAL, year
+        # Calculate discounted energy — end-of-period convention matches NPV OPEX discounting.
+        discount_rate_ratio = discount_rate * PERCENTAGE_TO_DECIMAL
+        full_years = int(system_lifetime)
+        discounted_energy = sum(
+            annual_energy / math.pow(1.0 + discount_rate_ratio, t) for t in range(1, full_years + 1)
+        )
+        fraction = system_lifetime - full_years
+        if fraction > 0:
+            discounted_energy += (
+                annual_energy * fraction / math.pow(1.0 + discount_rate_ratio, full_years + 1)
             )
 
         return npv / discounted_energy
@@ -472,6 +673,22 @@ class CostCalculator:
             return time_factor * factor * value * energy_sum
 
         return 0.0
+
+    def _get_effective_discount_rate(self, asset: Asset, fallback_rate: float) -> float:
+        """Return the discount rate to use for an asset, in percentage.
+
+        Uses the per-asset rate from ESDL costInformation when available,
+        falling back to ``fallback_rate`` otherwise.
+
+        Args:
+            asset: Asset to retrieve the discount rate for.
+            fallback_rate: System-level discount rate in percentage, used when
+                ``asset.discount_rate`` is None.
+
+        Returns:
+            Effective discount rate in percentage.
+        """
+        return asset.discount_rate if asset.discount_rate is not None else fallback_rate
 
     def _get_unit_factor(self, unit: str) -> float:
         """Get the conversion factor for a unit.

--- a/src/kpicalculator/calculators/energy_calculator.py
+++ b/src/kpicalculator/calculators/energy_calculator.py
@@ -165,6 +165,17 @@ class EnergyCalculator:
 
         return energy_sum * time_factor
 
+    def get_asset_energy_production_per_year(self, asset: Asset) -> float:
+        """Calculate annual energy production for a single producing asset.
+
+        Args:
+            asset: Producing asset (PRODUCER or GEOTHERMAL type).
+
+        Returns:
+            Energy production in joules per year, or 0.0 if no time series data.
+        """
+        return self._calculate_asset_energy_production(asset)
+
     def _calculate_asset_energy_production(self, asset: Asset) -> float:
         """Calculate energy production for a specific asset.
 

--- a/src/kpicalculator/calculators/financial_calculator.py
+++ b/src/kpicalculator/calculators/financial_calculator.py
@@ -1,6 +1,7 @@
-# src/kpicalculator/calculators/cost_calculator.py
+# src/kpicalculator/calculators/financial_calculator.py
 import logging
 import math
+from typing import TypedDict
 
 from ..adapters.common_model import Asset, AssetType, EnergySystem
 from ..common.constants import (
@@ -12,9 +13,42 @@ from ..exceptions import CalculationError
 
 logger = logging.getLogger(__name__)
 
+# Asset types that produce energy — used for per-asset LCOE eligibility.
+PRODUCER_ASSET_TYPES = frozenset({AssetType.PRODUCER, AssetType.GEOTHERMAL})
 
-class CostCalculator:
-    """Calculator for cost-related KPIs."""
+# Single taxonomy used by all category-based methods.
+_CATEGORY_MAPPING: dict[str, list[AssetType]] = {
+    "Production": [AssetType.PRODUCER, AssetType.GEOTHERMAL],
+    "Consumption": [AssetType.CONSUMER],
+    "Storage": [AssetType.STORAGE],
+    "Transport": [AssetType.TRANSPORT, AssetType.PIPE, AssetType.PUMP],
+    "Conversion": [AssetType.CONVERSION],
+}
+
+
+class AssetFinancialResult(TypedDict):
+    """Per-asset financial KPIs. System totals are derived by summing these across assets.
+
+    ``lcoe`` is ``None`` for non-producing assets (consumers, transport, storage) because
+    LCOE is a ratio of cost to energy output and is only meaningful for assets that
+    produce energy.
+    """
+
+    investment_cost: float
+    installation_cost: float
+    fixed_operational_cost: float
+    variable_operational_cost: float
+    fixed_maintenance_cost: float
+    variable_maintenance_cost: float
+    annualized_capex: float
+    eac: float
+    npv: float
+    tco: float
+    lcoe: float | None
+
+
+class FinancialCalculator:
+    """Calculator for financial KPIs (CAPEX, OPEX, NPV, LCOE, EAC, TCO)."""
 
     def __init__(self, energy_system: EnergySystem):
         """Initialize the cost calculator.
@@ -23,34 +57,6 @@ class CostCalculator:
             energy_system: Energy system to calculate KPIs for
         """
         self.energy_system = energy_system
-
-    def get_capex_by_category(self) -> dict[str, float]:
-        """Get CAPEX by asset category.
-
-        Returns:
-            Dictionary with CAPEX by category
-        """
-        categories = ["Production", "Consumption", "Storage", "Transport", "Conversion", "All"]
-        result = {}
-
-        for category in categories:
-            result[category] = self._calculate_capex_for_category(category)
-
-        return result
-
-    def get_opex_by_category(self) -> dict[str, float]:
-        """Get OPEX by asset category.
-
-        Returns:
-            Dictionary with OPEX by category
-        """
-        categories = ["Production", "Consumption", "Storage", "Transport", "Conversion", "All"]
-        result = {}
-
-        for category in categories:
-            result[category] = self._calculate_opex_for_category(category)
-
-        return result
 
     def calculate_npv(
         self,
@@ -101,7 +107,6 @@ class CostCalculator:
                     f"({asset.technical_lifetime}). Cannot compute NPV."
                 )
 
-            # Calculate NPV for CAPEX
             capex = asset.investment_cost + asset.installation_cost
             if round_up_replacement:
                 capex_npv = capex * sum(
@@ -112,7 +117,6 @@ class CostCalculator:
                 replacements = max(1.0, system_lifetime / asset.technical_lifetime)
                 capex_npv = capex * replacements
 
-            # Calculate NPV for OPEX
             opex_annual = (
                 self._calculate_fixed_operational_cost(asset)
                 + self._calculate_fixed_maintenance_cost(asset)
@@ -120,18 +124,11 @@ class CostCalculator:
                 + self._calculate_variable_maintenance_cost(asset)
             )
 
-            # End-of-period convention (standard engineering economics): OPEX at year t
-            # is discounted by (1+r)^t, t = 1..n. Consistent with the annuity formula
-            # in calculate_eac. A fractional final year is prorated linearly.
             full_years = int(system_lifetime)
-            opex_npv = opex_annual * sum(
-                1.0 / math.pow(1.0 + discount_rate_ratio, t) for t in range(1, full_years + 1)
-            )
             fraction = system_lifetime - full_years
-            if fraction > 0:
-                opex_npv += (
-                    opex_annual * fraction / math.pow(1.0 + discount_rate_ratio, full_years + 1)
-                )
+            opex_npv = self._compute_discounted_sum(
+                opex_annual, discount_rate_ratio, full_years, fraction
+            )
 
             npv += capex_npv + opex_npv
 
@@ -182,10 +179,7 @@ class CostCalculator:
             capex = self._calculate_investment_cost(asset) + self._calculate_installation_cost(
                 asset
             )
-            if r == 0.0:
-                annualized_capex = capex / asset.technical_lifetime
-            else:
-                annualized_capex = capex * r / (1.0 - math.pow(1.0 + r, -asset.technical_lifetime))
+            annualized_capex = self._annualize_capex(capex, r, asset.technical_lifetime)
 
             opex_annual = (
                 self._calculate_fixed_operational_cost(asset)
@@ -272,6 +266,7 @@ class CostCalculator:
         system_lifetime: float,
         discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT,
         round_up_replacement: bool = True,
+        system_npv: float | None = None,
     ) -> float:
         """Calculate Levelized Cost of Energy.
 
@@ -294,6 +289,9 @@ class CostCalculator:
             round_up_replacement: Passed through to ``calculate_npv``. If True (default),
                 use ``ceil`` for the replacement count. If False, use the continuous
                 factor for optimizer compatibility.
+            system_npv: Pre-computed system NPV in EUR. When provided, skips the internal
+                ``calculate_npv()`` call. Pass this from ``KpiManager.calculate_all_kpis()``
+                to avoid a redundant full asset iteration.
 
         Returns:
             Levelized Cost of Energy in EUR/MWh.
@@ -311,84 +309,307 @@ class CostCalculator:
         if annual_energy <= 0:
             return 0.0
 
-        npv = self.calculate_npv(
-            system_lifetime, discount_rate, round_up_replacement=round_up_replacement
-        )
-
-        # Calculate discounted energy — end-of-period convention matches NPV OPEX discounting.
-        discount_rate_ratio = discount_rate * PERCENTAGE_TO_DECIMAL
-        full_years = int(system_lifetime)
-        discounted_energy = sum(
-            annual_energy / math.pow(1.0 + discount_rate_ratio, t) for t in range(1, full_years + 1)
-        )
-        fraction = system_lifetime - full_years
-        if fraction > 0:
-            discounted_energy += (
-                annual_energy * fraction / math.pow(1.0 + discount_rate_ratio, full_years + 1)
+        if system_npv is None:
+            system_npv = self.calculate_npv(
+                system_lifetime, discount_rate, round_up_replacement=round_up_replacement
             )
 
-        return npv / discounted_energy
+        discount_rate_ratio = discount_rate * PERCENTAGE_TO_DECIMAL
+        full_years = int(system_lifetime)
+        fraction = system_lifetime - full_years
+        discounted_energy = self._compute_discounted_sum(
+            annual_energy, discount_rate_ratio, full_years, fraction
+        )
 
-    def _calculate_capex_for_category(self, category: str) -> float:
-        """Calculate CAPEX for a specific asset category.
+        return system_npv / discounted_energy
+
+    def get_asset_financial_breakdown(
+        self,
+        system_lifetime: float,
+        discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT,
+        round_up_replacement: bool = True,
+        annual_energy_mwh_by_asset: dict[str, float] | None = None,
+    ) -> dict[str, AssetFinancialResult]:
+        """Compute per-asset financial KPIs.
+
+        Returns a dict keyed by ``asset.id``. System totals for NPV, TCO, EAC are
+        the sum of these values across all assets.
+
+        ``lcoe`` semantics:
+
+        - ``None`` — asset is not a generating type (consumer, storage, transport,
+          conversion), or is a generating asset whose annual energy production is zero
+          or unknown. ``None`` means *not applicable or not computable*, regardless of
+          the output format (ESDL, JSON, or any future schema). Exporters omit the field
+          or write a format-appropriate null for ``None`` values.
+        - ``float`` — EUR/MWh; only set for generating assets with non-zero energy output.
+
+        System LCOE must be computed separately as total NPV / total discounted energy
+        output — it is not the sum of per-asset LCOEs (summing ratios with different
+        denominators is mathematically incorrect).
+
+        Raises:
+            CalculationError: If ``system_lifetime <= 0``, ``discount_rate`` is outside
+                [0, 100], or any asset has a non-positive ``technical_lifetime``.
 
         Args:
-            category: Asset category
+            system_lifetime: System lifetime in years.
+            discount_rate: Fallback discount rate in percentage (e.g. 5 for 5%).
+            round_up_replacement: If True (default), use ``ceil`` for replacement count.
+                If False, use the continuous factor for optimizer compatibility.
+            annual_energy_mwh_by_asset: Optional mapping of asset ID to annual energy
+                production in MWh. When provided, ``lcoe`` is computed for generating
+                assets (those in ``PRODUCER_ASSET_TYPES``) with non-zero energy.
+                When ``None`` (default), ``lcoe`` is ``None`` for all assets.
+                Callers that hold an energy calculator should pre-compute this dict
+                and pass it here rather than relying on a post-hoc fill step.
 
         Returns:
-            CAPEX for the category
+            Dict mapping asset ID to its ``AssetFinancialResult``.
         """
-        capex = 0.0
+        if system_lifetime <= 0:
+            raise CalculationError(f"system_lifetime must be positive (got {system_lifetime}).")
+        if discount_rate < 0 or discount_rate > 100:
+            raise CalculationError(
+                f"discount_rate must be between 0 and 100 (got {discount_rate})."
+            )
+
+        result: dict[str, AssetFinancialResult] = {}
+        discount_rate_ratio = discount_rate * PERCENTAGE_TO_DECIMAL
+        full_years = int(system_lifetime)
+        fraction = system_lifetime - full_years
 
         for asset in self.energy_system.assets:
-            if category == "All" or self._asset_belongs_to_category(asset, category):
-                capex += self._calculate_investment_cost(asset) + self._calculate_installation_cost(
-                    asset
+            if asset.technical_lifetime <= 0:
+                raise CalculationError(
+                    f"Asset '{asset.name}' has non-positive technical_lifetime "
+                    f"({asset.technical_lifetime}). Cannot compute financial breakdown."
                 )
+            result[asset.id] = self._compute_asset_result(
+                asset,
+                system_lifetime,
+                discount_rate,
+                discount_rate_ratio,
+                full_years,
+                fraction,
+                round_up_replacement,
+                annual_energy_mwh_by_asset,
+            )
 
-        return capex
+        return result
 
-    def _calculate_opex_for_category(self, category: str) -> float:
-        """Calculate OPEX for a specific asset category.
+    def _compute_asset_result(  # pylint: disable=too-many-locals
+        self,
+        asset: Asset,
+        system_lifetime: float,
+        discount_rate: float,
+        discount_rate_ratio: float,
+        full_years: int,
+        fraction: float,
+        round_up_replacement: bool,
+        annual_energy_mwh_by_asset: dict[str, float] | None,
+    ) -> AssetFinancialResult:
+        """Compute all financial KPIs for a single asset."""
+        investment_cost = self._calculate_investment_cost(asset)
+        installation_cost = self._calculate_installation_cost(asset)
+        fixed_operational_cost = self._calculate_fixed_operational_cost(asset)
+        variable_operational_cost = self._calculate_variable_operational_cost(asset)
+        fixed_maintenance_cost = self._calculate_fixed_maintenance_cost(asset)
+        variable_maintenance_cost = self._calculate_variable_maintenance_cost(asset)
+
+        capex = investment_cost + installation_cost
+        opex_annual = (
+            fixed_operational_cost
+            + variable_operational_cost
+            + fixed_maintenance_cost
+            + variable_maintenance_cost
+        )
+
+        r = self._get_effective_discount_rate(asset, discount_rate) * PERCENTAGE_TO_DECIMAL
+        annualized_capex = self._annualize_capex(capex, r, asset.technical_lifetime)
+        eac = annualized_capex + opex_annual
+
+        npv, tco = self._compute_asset_npv_tco(
+            capex,
+            opex_annual,
+            asset.technical_lifetime,
+            system_lifetime,
+            discount_rate_ratio,
+            full_years,
+            fraction,
+            round_up_replacement,
+        )
+        lcoe = self._compute_asset_lcoe(
+            npv,
+            asset,
+            annual_energy_mwh_by_asset,
+            discount_rate_ratio,
+            full_years,
+            fraction,
+        )
+
+        return AssetFinancialResult(
+            investment_cost=investment_cost,
+            installation_cost=installation_cost,
+            fixed_operational_cost=fixed_operational_cost,
+            variable_operational_cost=variable_operational_cost,
+            fixed_maintenance_cost=fixed_maintenance_cost,
+            variable_maintenance_cost=variable_maintenance_cost,
+            annualized_capex=annualized_capex,
+            eac=eac,
+            npv=npv,
+            tco=tco,
+            lcoe=lcoe,
+        )
+
+    def _compute_asset_npv_tco(
+        self,
+        capex: float,
+        opex_annual: float,
+        technical_lifetime: float,
+        system_lifetime: float,
+        discount_rate_ratio: float,
+        full_years: int,
+        fraction: float,
+        round_up_replacement: bool,
+    ) -> tuple[float, float]:
+        """Compute NPV and TCO for a single asset."""
+        if round_up_replacement:
+            n_replacements: int = math.ceil(system_lifetime / technical_lifetime)
+            replacements: float = n_replacements
+            capex_npv = capex * sum(
+                1.0 / math.pow(1.0 + discount_rate_ratio, technical_lifetime * n)
+                for n in range(n_replacements)
+            )
+        else:
+            replacements = max(1.0, system_lifetime / technical_lifetime)
+            capex_npv = capex * replacements
+
+        opex_npv = self._compute_discounted_sum(
+            opex_annual, discount_rate_ratio, full_years, fraction
+        )
+
+        npv = capex_npv + opex_npv
+        tco = capex * replacements + opex_annual * system_lifetime
+        return npv, tco
+
+    def _compute_asset_lcoe(
+        self,
+        npv: float,
+        asset: Asset,
+        annual_energy_mwh_by_asset: dict[str, float] | None,
+        discount_rate_ratio: float,
+        full_years: int,
+        fraction: float,
+    ) -> float | None:
+        """Compute per-asset LCOE, or return None if not applicable or not computable."""
+        if annual_energy_mwh_by_asset is None or asset.asset_type not in PRODUCER_ASSET_TYPES:
+            return None
+        annual_energy_mwh = annual_energy_mwh_by_asset.get(asset.id, 0.0)
+        if annual_energy_mwh <= 0:
+            return None
+        discounted_energy = self._compute_discounted_sum(
+            annual_energy_mwh, discount_rate_ratio, full_years, fraction
+        )
+        return npv / discounted_energy if discounted_energy > 0 else None
+
+    def _annualize_capex(self, capex: float, r: float, technical_lifetime: float) -> float:
+        """Annualize a CAPEX amount using the annuity formula.
 
         Args:
-            category: Asset category
+            capex: Capital cost in EUR.
+            r: Discount rate as a decimal (e.g. 0.05 for 5%).
+            technical_lifetime: Asset technical lifetime in years.
 
         Returns:
-            OPEX for the category
+            Annualized CAPEX in EUR/yr.
         """
-        opex = 0.0
+        if r == 0.0:
+            return capex / technical_lifetime
+        return capex * r / (1.0 - math.pow(1.0 + r, -technical_lifetime))
+
+    @staticmethod
+    def _compute_discounted_sum(
+        annual_value: float,
+        discount_rate_ratio: float,
+        full_years: int,
+        fraction: float,
+    ) -> float:
+        """Compute the present value of a constant annual amount over a fractional lifetime.
+
+        Uses end-of-period convention: cash flow at year t is discounted by (1+r)^t.
+        A fractional final year is prorated linearly. Consistent with the annuity
+        formula used in ``_annualize_capex``.
+
+        Args:
+            annual_value: Constant annual amount (e.g. energy MWh or cost EUR/yr).
+            discount_rate_ratio: Discount rate as a decimal (e.g. 0.05 for 5%).
+            full_years: Integer number of complete years.
+            fraction: Fractional remainder of the final year (0 ≤ fraction < 1).
+
+        Returns:
+            Present value of the annual amount stream.
+        """
+        total = annual_value * sum(
+            1.0 / math.pow(1.0 + discount_rate_ratio, t) for t in range(1, full_years + 1)
+        )
+        if fraction > 0:
+            total += annual_value * fraction / math.pow(1.0 + discount_rate_ratio, full_years + 1)
+        return total
+
+    def _get_asset_category(self, asset: Asset) -> str:
+        """Return the named category for an asset, or 'Other' if unrecognised.
+
+        Args:
+            asset: Asset to classify.
+
+        Returns:
+            Category name string.
+        """
+        for category, types in _CATEGORY_MAPPING.items():
+            if asset.asset_type in types:
+                return category
+        return "Other"
+
+    def aggregate_by_category(
+        self, asset_financials: dict[str, "AssetFinancialResult"]
+    ) -> tuple[dict[str, float], dict[str, float]]:
+        """Derive CAPEX and OPEX category breakdowns from a pre-computed asset breakdown.
+
+        Args:
+            asset_financials: Dict mapping asset ID to ``AssetFinancialResult``, as
+                returned by ``get_asset_financial_breakdown()``.
+
+        Returns:
+            Tuple of (capex_by_category, opex_by_category), each a dict with keys
+            ``"Production"``, ``"Consumption"``, ``"Storage"``, ``"Transport"``,
+            ``"Conversion"``, and ``"All"``.
+        """
+        categories = list(_CATEGORY_MAPPING.keys())
+        capex: dict[str, float] = dict.fromkeys(categories, 0.0)
+        capex["All"] = 0.0
+        opex: dict[str, float] = dict.fromkeys(categories, 0.0)
+        opex["All"] = 0.0
 
         for asset in self.energy_system.assets:
-            if category == "All" or self._asset_belongs_to_category(asset, category):
-                opex += (
-                    self._calculate_fixed_operational_cost(asset)
-                    + self._calculate_variable_operational_cost(asset)
-                    + self._calculate_fixed_maintenance_cost(asset)
-                    + self._calculate_variable_maintenance_cost(asset)
-                )
+            financials = asset_financials.get(asset.id)
+            if financials is None:
+                continue
+            cat = self._get_asset_category(asset)
+            asset_capex = financials["investment_cost"] + financials["installation_cost"]
+            asset_opex = (
+                financials["fixed_operational_cost"]
+                + financials["variable_operational_cost"]
+                + financials["fixed_maintenance_cost"]
+                + financials["variable_maintenance_cost"]
+            )
+            if cat in capex:
+                capex[cat] += asset_capex
+                opex[cat] += asset_opex
+            capex["All"] += asset_capex
+            opex["All"] += asset_opex
 
-        return opex
-
-    def _asset_belongs_to_category(self, asset: Asset, category: str) -> bool:
-        """Check if an asset belongs to a specific category.
-
-        Args:
-            asset: Asset to check
-            category: Category to check
-
-        Returns:
-            True if the asset belongs to the category, False otherwise
-        """
-        category_mapping = {
-            "Production": [AssetType.PRODUCER, AssetType.GEOTHERMAL],
-            "Consumption": [AssetType.CONSUMER],
-            "Storage": [AssetType.STORAGE],
-            "Transport": [AssetType.TRANSPORT, AssetType.PIPE, AssetType.PUMP],
-            "Conversion": [AssetType.CONVERSION],
-        }
-
-        return asset.asset_type in category_mapping.get(category, [])
+        return capex, opex
 
     def _calculate_investment_cost(self, asset: Asset) -> float:
         """Calculate investment cost for an asset.

--- a/src/kpicalculator/calculators/financial_calculator.py
+++ b/src/kpicalculator/calculators/financial_calculator.py
@@ -27,24 +27,56 @@ _CATEGORY_MAPPING: dict[str, list[AssetType]] = {
 
 
 class AssetFinancialResult(TypedDict):
-    """Per-asset financial KPIs. System totals are derived by summing these across assets.
+    """Per-asset financial KPIs returned in ``KpiResults["asset_financials"]``.
 
-    ``lcoe`` is ``None`` for non-producing assets (consumers, transport, storage) because
-    LCOE is a ratio of cost to energy output and is only meaningful for assets that
-    produce energy.
+    System totals in ``KpiResults["financials"]`` are derived by summing the
+    corresponding field across all assets (except ``lcoe`` — see below).
+
+    **Per-asset discount rate:** all discounted KPIs (``annualized_capex``,
+    ``eac``, ``npv``, and ``lcoe``) use the discount rate from
+    ``costInformation.discountRate`` in the ESDL when present; otherwise the
+    system-level ``discount_rate`` parameter is used as a fallback.
+
+    **Geothermal COP adjustment:** variable operational and maintenance costs
+    in EUR/kWh or EUR/MWh are applied to ``energy / COP`` for geothermal
+    assets with COP > 0, reflecting that they deliver more heat than they
+    consume as input.
     """
 
     investment_cost: float
+    """Upfront capital cost in EUR."""
     installation_cost: float
+    """Installation cost in EUR."""
     fixed_operational_cost: float
+    """Annual fixed operational cost in EUR/year."""
     variable_operational_cost: float
+    """Annual variable operational cost in EUR/year (scales with energy use)."""
     fixed_maintenance_cost: float
+    """Annual fixed maintenance cost in EUR/year."""
     variable_maintenance_cost: float
+    """Annual variable maintenance cost in EUR/year (scales with energy use)."""
     annualized_capex: float
+    """CAPEX spread over the asset's technical lifetime via the annuity formula, in EUR/year.
+    At discount_rate = 0% this reduces to (investment + installation) / technical_lifetime."""
     eac: float
+    """Equivalent Annual Cost: annualized_capex + total annual OPEX, in EUR/year."""
     npv: float
+    """Discounted lifecycle cost of this asset in EUR."""
     tco: float
+    """Undiscounted total spend on this asset over the system lifetime, in EUR."""
     lcoe: float | None
+    """Levelized Cost of Energy in EUR/MWh for this asset, or ``None``.
+
+    ``None`` when:
+
+    - the asset is not a generating type (consumers, transport, storage, conversion), or
+    - the asset is a generating type but its annual energy production is zero or unknown
+      (no time series data supplied).
+
+    ``None`` means *not applicable or not computable* — exporters should omit the field
+    or write a format-appropriate null. The system LCOE is computed separately as
+    ``total_npv / total_discounted_energy`` and is not the average of per-asset LCOEs.
+    """
 
 
 class FinancialCalculator:
@@ -57,6 +89,17 @@ class FinancialCalculator:
             energy_system: Energy system to calculate KPIs for
         """
         self.energy_system = energy_system
+
+    @staticmethod
+    def _split_lifetime(system_lifetime: float) -> tuple[int, float]:
+        """Split system lifetime into whole years and fractional remainder.
+
+        Returns:
+            ``(full_years, fraction)`` where ``full_years = int(system_lifetime)``
+            and ``fraction = system_lifetime - full_years``.
+        """
+        full_years = int(system_lifetime)
+        return full_years, system_lifetime - full_years
 
     def calculate_npv(
         self,
@@ -80,9 +123,22 @@ class FinancialCalculator:
             CalculationError: If ``system_lifetime <= 0``, ``discount_rate`` is outside
                 [0, 100], or any asset has a non-positive ``technical_lifetime``.
 
+        .. note::
+            This method applies a single uniform ``discount_rate`` to all assets
+            and does not respect per-asset discount rates from ESDL
+            ``costInformation.discountRate``. It is not used in the main
+            calculation path — ``KpiManager.calculate_all_kpis()`` derives
+            system NPV by summing per-asset NPVs from
+            ``get_asset_financial_breakdown()``, and ``calculate_lcoe()``
+            does the same when no ``system_npv`` is supplied. Use this method
+            only when a quick uniform-rate NPV estimate is needed without the
+            full per-asset breakdown.
+
         Args:
             system_lifetime: System lifetime in years. May be fractional.
             discount_rate: Discount rate in percentage (e.g. 5 for 5%).
+                Applied uniformly to all assets — per-asset overrides are
+                not supported here.
             round_up_replacement: If True (default), use ``ceil`` for the replacement
                 count with per-replacement discounting. If False, use the continuous
                 factor ``max(1, n / technical_lifetime)`` for optimizer compatibility.
@@ -124,8 +180,7 @@ class FinancialCalculator:
                 + self._calculate_variable_maintenance_cost(asset)
             )
 
-            full_years = int(system_lifetime)
-            fraction = system_lifetime - full_years
+            full_years, fraction = self._split_lifetime(system_lifetime)
             opex_npv = self._compute_discounted_sum(
                 opex_annual, discount_rate_ratio, full_years, fraction
             )
@@ -274,10 +329,12 @@ class FinancialCalculator:
         present-value basis. Energy discounting uses the same end-of-period convention
         and fractional-year proration as NPV OPEX. See ``kpi_guide.rst`` for the formula.
 
-        The ``round_up_replacement`` flag is passed through to ``calculate_npv``; see
-        that method for its effect on CAPEX replacement counting.
-
         Returns 0.0 if annual energy consumption is zero or negative.
+
+        When ``system_npv`` is not provided, it is derived by summing per-asset
+        NPVs from ``get_asset_financial_breakdown()``, which respects per-asset
+        discount rates from ESDL ``costInformation.discountRate``. This differs
+        from ``calculate_npv()``, which applies a uniform rate to all assets.
 
         Raises:
             CalculationError: If ``system_lifetime <= 0``, ``discount_rate`` is outside
@@ -285,13 +342,13 @@ class FinancialCalculator:
 
         Args:
             system_lifetime: System lifetime in years. May be fractional.
-            discount_rate: Discount rate in percentage (e.g. 5 for 5%).
-            round_up_replacement: Passed through to ``calculate_npv``. If True (default),
-                use ``ceil`` for the replacement count. If False, use the continuous
-                factor for optimizer compatibility.
-            system_npv: Pre-computed system NPV in EUR. When provided, skips the internal
-                ``calculate_npv()`` call. Pass this from ``KpiManager.calculate_all_kpis()``
-                to avoid a redundant full asset iteration.
+            discount_rate: System-wide fallback discount rate in percentage (e.g. 5
+                for 5%). Per-asset overrides from ESDL are applied automatically.
+            round_up_replacement: If True (default), use ``ceil`` for the replacement
+                count. If False, use the continuous factor for optimizer compatibility.
+            system_npv: Pre-computed system NPV in EUR. When provided, skips the
+                internal asset iteration. Pass this from
+                ``KpiManager.calculate_all_kpis()`` to avoid a redundant computation.
 
         Returns:
             Levelized Cost of Energy in EUR/MWh.
@@ -310,13 +367,13 @@ class FinancialCalculator:
             return 0.0
 
         if system_npv is None:
-            system_npv = self.calculate_npv(
+            asset_financials = self.get_asset_financial_breakdown(
                 system_lifetime, discount_rate, round_up_replacement=round_up_replacement
             )
+            system_npv = sum(r["npv"] for r in asset_financials.values())
 
         discount_rate_ratio = discount_rate * PERCENTAGE_TO_DECIMAL
-        full_years = int(system_lifetime)
-        fraction = system_lifetime - full_years
+        full_years, fraction = self._split_lifetime(system_lifetime)
         discounted_energy = self._compute_discounted_sum(
             annual_energy, discount_rate_ratio, full_years, fraction
         )
@@ -354,15 +411,21 @@ class FinancialCalculator:
 
         Args:
             system_lifetime: System lifetime in years.
-            discount_rate: Fallback discount rate in percentage (e.g. 5 for 5%).
-            round_up_replacement: If True (default), use ``ceil`` for replacement count.
-                If False, use the continuous factor for optimizer compatibility.
-            annual_energy_mwh_by_asset: Optional mapping of asset ID to annual energy
-                production in MWh. When provided, ``lcoe`` is computed for generating
-                assets (those in ``PRODUCER_ASSET_TYPES``) with non-zero energy.
-                When ``None`` (default), ``lcoe`` is ``None`` for all assets.
-                Callers that hold an energy calculator should pre-compute this dict
-                and pass it here rather than relying on a post-hoc fill step.
+            discount_rate: System-wide fallback discount rate in percentage
+                (e.g. 5 for 5%). Individual assets override this when
+                ``asset.discount_rate`` is set (from ESDL
+                ``costInformation.discountRate``).
+            round_up_replacement: If True (default), use ``ceil`` for the
+                replacement count — the financially exact calculation. If
+                False, uses the continuous factor
+                ``max(1, system_lifetime / technical_lifetime)`` for
+                MESIDO optimizer compatibility.
+            annual_energy_mwh_by_asset: Optional mapping of asset ID to annual
+                energy production in MWh. When provided, ``lcoe`` is computed
+                for generating assets (those in ``PRODUCER_ASSET_TYPES``) with
+                non-zero energy. When ``None`` (default), ``lcoe`` is ``None``
+                for all assets. Callers that hold an energy calculator should
+                pre-compute this dict and pass it here.
 
         Returns:
             Dict mapping asset ID to its ``AssetFinancialResult``.
@@ -375,9 +438,7 @@ class FinancialCalculator:
             )
 
         result: dict[str, AssetFinancialResult] = {}
-        discount_rate_ratio = discount_rate * PERCENTAGE_TO_DECIMAL
-        full_years = int(system_lifetime)
-        fraction = system_lifetime - full_years
+        full_years, fraction = self._split_lifetime(system_lifetime)
 
         for asset in self.energy_system.assets:
             if asset.technical_lifetime <= 0:
@@ -389,7 +450,6 @@ class FinancialCalculator:
                 asset,
                 system_lifetime,
                 discount_rate,
-                discount_rate_ratio,
                 full_years,
                 fraction,
                 round_up_replacement,
@@ -403,13 +463,17 @@ class FinancialCalculator:
         asset: Asset,
         system_lifetime: float,
         discount_rate: float,
-        discount_rate_ratio: float,
         full_years: int,
         fraction: float,
         round_up_replacement: bool,
         annual_energy_mwh_by_asset: dict[str, float] | None,
     ) -> AssetFinancialResult:
-        """Compute all financial KPIs for a single asset."""
+        """Compute all financial KPIs for a single asset.
+
+        The effective per-asset discount rate (``asset_discount_rate_ratio``)
+        is resolved via ``_get_effective_discount_rate`` and used for all
+        discounted KPIs.
+        """
         investment_cost = self._calculate_investment_cost(asset)
         installation_cost = self._calculate_installation_cost(asset)
         fixed_operational_cost = self._calculate_fixed_operational_cost(asset)
@@ -425,8 +489,12 @@ class FinancialCalculator:
             + variable_maintenance_cost
         )
 
-        r = self._get_effective_discount_rate(asset, discount_rate) * PERCENTAGE_TO_DECIMAL
-        annualized_capex = self._annualize_capex(capex, r, asset.technical_lifetime)
+        asset_discount_rate_ratio = (
+            self._get_effective_discount_rate(asset, discount_rate) * PERCENTAGE_TO_DECIMAL
+        )
+        annualized_capex = self._annualize_capex(
+            capex, asset_discount_rate_ratio, asset.technical_lifetime
+        )
         eac = annualized_capex + opex_annual
 
         npv, tco = self._compute_asset_npv_tco(
@@ -434,7 +502,7 @@ class FinancialCalculator:
             opex_annual,
             asset.technical_lifetime,
             system_lifetime,
-            discount_rate_ratio,
+            asset_discount_rate_ratio,
             full_years,
             fraction,
             round_up_replacement,
@@ -443,7 +511,7 @@ class FinancialCalculator:
             npv,
             asset,
             annual_energy_mwh_by_asset,
-            discount_rate_ratio,
+            asset_discount_rate_ratio,
             full_years,
             fraction,
         )

--- a/src/kpicalculator/common/constants.py
+++ b/src/kpicalculator/common/constants.py
@@ -74,16 +74,35 @@ COMPOSITE_KEY_SEPARATOR = "|"
 # Each tuple defines the priority order in which field names are tried for
 # a given energy category. The calculators import these directly so there
 # is a single source of truth.
-CONSUMPTION_FIELDS: tuple[str, ...] = ("ThermalConsumption", "Consumption", "Energy")
+CONSUMPTION_FIELDS: tuple[str, ...] = (
+    "ThermalConsumption",
+    "Consumption",
+    "Energy",
+    "heat_power_primary",  # HeatPump/HeatExchanger primary side (consumer of heat)
+)
 DEMAND_FIELDS: tuple[str, ...] = ("ThermalDemand", "Demand", "heat_demand")
-PRODUCTION_FIELDS: tuple[str, ...] = ("ThermalProduction", "Production", "heat_supplied", "Energy")
+PRODUCTION_FIELDS: tuple[str, ...] = (
+    "ThermalProduction",
+    "Production",
+    "heat_supplied",
+    "Energy",
+    "heat_power_secondary",  # HeatPump/HeatExchanger secondary side (producer of heat)
+)
 ELECTRICAL_CONSUMPTION_FIELDS: tuple[str, ...] = ("ElectricalConsumption",)
-CONVERSION_FIELDS: tuple[str, ...] = ("ElectricalConsumption", "ThermalProduction")
+CONVERSION_FIELDS: tuple[str, ...] = (
+    "ElectricalConsumption",
+    "electricity_consumption",  # simulator-core field name (lowercase)
+    "ThermalProduction",
+)
 
 # Union of all recognised field names — used to warn when a DataFrame column
 # will not contribute to any KPI calculation.
 KNOWN_TIME_SERIES_FIELDS: frozenset[str] = frozenset(
-    CONSUMPTION_FIELDS + DEMAND_FIELDS + PRODUCTION_FIELDS + ELECTRICAL_CONSUMPTION_FIELDS
+    CONSUMPTION_FIELDS
+    + DEMAND_FIELDS
+    + PRODUCTION_FIELDS
+    + ELECTRICAL_CONSUMPTION_FIELDS
+    + CONVERSION_FIELDS
 )
 # Security-related ports to validate against
 DANGEROUS_PORTS = {22, 23, 80, 3389, 5985, 5986}  # SSH, Telnet, HTTP, RDP, WinRM

--- a/src/kpicalculator/kpi_manager.py
+++ b/src/kpicalculator/kpi_manager.py
@@ -8,13 +8,23 @@ from esdl import esdl
 from .adapters.common_model import EnergySystem
 from .adapters.esdl_adapter import EsdlAdapter
 from .adapters.simulator_adapter import SimulatorAdapter
-from .common.constants import DEFAULT_DISCOUNT_RATE_PERCENT, DEFAULT_SYSTEM_LIFETIME_YEARS
+from .calculators.emission_calculator import EmissionCalculator
+from .calculators.energy_calculator import EnergyCalculator
+from .calculators.financial_calculator import (
+    PRODUCER_ASSET_TYPES,
+    AssetFinancialResult,
+    FinancialCalculator,
+)
+from .common.constants import (
+    DEFAULT_DISCOUNT_RATE_PERCENT,
+    DEFAULT_SYSTEM_LIFETIME_YEARS,
+)
 
 _logger = logging.getLogger(__name__)
 
 
-class CostResults(TypedDict):
-    """Results structure for cost calculations."""
+class FinancialResults(TypedDict):
+    """System-level financial KPI results. All values are sums over assets."""
 
     capex: dict[str, float]
     opex: dict[str, float]
@@ -43,9 +53,10 @@ class EmissionResults(TypedDict):
 class KpiResults(TypedDict):
     """Complete KPI results structure."""
 
-    costs: CostResults
+    financials: FinancialResults
     energy: EnergyResults
     emissions: EmissionResults
+    asset_financials: dict[str, AssetFinancialResult]
 
 
 class KpiManager:
@@ -176,29 +187,50 @@ class KpiManager:
         if discount_rate < 0 or discount_rate > 100:
             raise ValueError(f"discount_rate must be between 0 and 100 (got {discount_rate}).")
 
-        from .calculators.cost_calculator import CostCalculator
-        from .calculators.emission_calculator import EmissionCalculator
-        from .calculators.energy_calculator import EnergyCalculator
-
-        cost_calc = CostCalculator(self.energy_system)
+        cost_calc = FinancialCalculator(self.energy_system)
         energy_calc = EnergyCalculator(self.energy_system)
         emission_calc = EmissionCalculator(self.energy_system)
 
+        # Pre-compute annual energy production (MWh) for generating assets so
+        # FinancialCalculator can compute per-asset LCOE in its single pass.
+        # Non-generating assets are omitted; FinancialCalculator treats a missing key as 0.
+        annual_energy_mwh_by_asset = {
+            asset.id: energy_calc.get_asset_energy_production_per_year(asset) / 3.6e9
+            for asset in self.energy_system.assets
+            if asset.asset_type in PRODUCER_ASSET_TYPES
+        }
+
+        asset_financials = cost_calc.get_asset_financial_breakdown(
+            system_lifetime,
+            discount_rate,
+            round_up_replacement=round_up_replacement,
+            annual_energy_mwh_by_asset=annual_energy_mwh_by_asset,
+        )
+
+        system_npv = 0.0
+        system_eac = 0.0
+        system_tco = 0.0
+        for r in asset_financials.values():
+            system_npv += r["npv"]
+            system_eac += r["eac"]
+            system_tco += r["tco"]
+        capex_by_cat, opex_by_cat = cost_calc.aggregate_by_category(asset_financials)
+
         results: KpiResults = {
-            "costs": {
-                "capex": cost_calc.get_capex_by_category(),
-                "opex": cost_calc.get_opex_by_category(),
-                "npv": cost_calc.calculate_npv(
-                    system_lifetime, discount_rate, round_up_replacement=round_up_replacement
-                ),
+            "financials": {
+                "capex": capex_by_cat,
+                "opex": opex_by_cat,
+                "npv": system_npv,
+                # System LCOE = total NPV / total discounted energy — not a sum of per-asset LCOEs.
                 "lcoe": cost_calc.calculate_lcoe(
-                    system_lifetime, discount_rate, round_up_replacement=round_up_replacement
+                    system_lifetime,
+                    discount_rate,
+                    round_up_replacement=round_up_replacement,
+                    system_npv=system_npv,
                 ),
-                "eac": cost_calc.calculate_eac(discount_rate),
+                "eac": system_eac,
                 # TCO is intentionally undiscounted — discount_rate is not used.
-                "tco": cost_calc.calculate_tco(
-                    system_lifetime, round_up_replacement=round_up_replacement
-                ),
+                "tco": system_tco,
             },
             "energy": {
                 "consumption": energy_calc.get_total_energy_consumption_per_year(),
@@ -210,6 +242,7 @@ class KpiManager:
                 "total": emission_calc.get_total_emissions(),
                 "per_mwh": emission_calc.get_emissions_per_mwh(),
             },
+            "asset_financials": asset_financials,
         }
 
         no_asset_has_time_series = not any(asset.time_series for asset in self.energy_system.assets)

--- a/src/kpicalculator/kpi_manager.py
+++ b/src/kpicalculator/kpi_manager.py
@@ -20,38 +20,85 @@ from .common.constants import (
     DEFAULT_SYSTEM_LIFETIME_YEARS,
 )
 
+# Public API of this module — controls re-exports recognised by mypy and static analysers.
+__all__ = [
+    "AssetFinancialResult",
+    "EmissionResults",
+    "EnergyResults",
+    "FinancialResults",
+    "KpiManager",
+    "KpiResults",
+]
+
 _logger = logging.getLogger(__name__)
 
 
 class FinancialResults(TypedDict):
-    """System-level financial KPI results. All values are sums over assets."""
+    """System-level financial KPI results.
+
+    All monetary values are in EUR or EUR/year. Each field is the sum of the
+    corresponding per-asset value across all assets in the system (except
+    ``lcoe``, which is computed as ``sum(per-asset NPVs) / total_discounted_energy``
+    and is therefore *not* the average of per-asset LCOEs).
+
+    ``capex`` and ``opex`` are broken down by asset category:
+    ``"Production"``, ``"Consumption"``, ``"Storage"``, ``"Transport"``,
+    ``"Conversion"``, and ``"All"`` (the system-wide sum).
+    """
 
     capex: dict[str, float]
+    """CAPEX by asset category in EUR (investment + installation costs)."""
     opex: dict[str, float]
+    """Annual OPEX by asset category in EUR/year (fixed + variable costs)."""
     npv: float
+    """Net Present Value — discounted lifecycle cost in EUR."""
     lcoe: float
+    """Levelized Cost of Energy in EUR/MWh (``system_npv / discounted_energy``).
+
+    ``system_npv`` is the sum of per-asset NPVs, each discounted at the
+    asset's own rate (from ESDL ``costInformation.discountRate``, falling back
+    to the system default). It is not the average of per-asset LCOEs.
+    """
     eac: float
+    """Equivalent Annual Cost — sum of per-asset annualized costs in EUR/year."""
     tco: float
+    """Total Cost of Ownership — undiscounted lifecycle cost in EUR."""
 
 
 class EnergyResults(TypedDict):
-    """Results structure for energy calculations."""
+    """System-level energy KPI results. All values in Joules."""
 
     consumption: float
+    """Total thermal energy consumed by all consumer assets in J."""
     demand: float
+    """Total thermal energy demand from all consumer assets in J."""
     production: float
+    """Total thermal energy produced by all producer assets in J."""
     efficiency: float
+    """Distribution efficiency: consumption / production (0-1). Zero when production is zero."""
 
 
 class EmissionResults(TypedDict):
-    """Results structure for emission calculations."""
+    """System-level emission KPI results."""
 
     total: float
+    """Total greenhouse gas emissions in tonnes CO2e/year."""
     per_mwh: float
+    """Emission intensity in kg CO2e/MWh of energy consumed."""
 
 
 class KpiResults(TypedDict):
-    """Complete KPI results structure."""
+    """Complete KPI results returned by ``KpiManager.calculate_all_kpis()`` and the
+    top-level ``kpicalculator.calculate_kpis()`` function.
+
+    Four top-level keys:
+
+    - ``financials``: system-level monetary KPIs (CAPEX, OPEX, NPV, LCOE, EAC, TCO)
+    - ``energy``: system-level energy totals in Joules
+    - ``emissions``: system-level CO2e emissions
+    - ``asset_financials``: per-asset financial breakdown keyed by asset ID;
+      system totals in ``financials`` are derived by summing these values
+    """
 
     financials: FinancialResults
     energy: EnergyResults
@@ -171,14 +218,25 @@ class KpiManager:
 
         Args:
             system_lifetime: System lifetime in years. Must be positive.
-            discount_rate: Discount rate in percentage (e.g. 5 for 5%). Must be in [0, 100].
-            round_up_replacement: If True (default), NPV, LCOE, and TCO use ``ceil``
-                for the asset replacement count (financially exact). If False, uses the
-                continuous factor ``max(1, n / technical_lifetime)`` for optimizer
-                compatibility.
+                Default: 30 years.
+            discount_rate: System-wide fallback discount rate in percentage
+                (e.g. 5 for 5%). Must be in [0, 100]. Individual assets may
+                override this via ``costInformation.discountRate`` in the ESDL
+                — this method respects those overrides because it uses
+                ``get_asset_financial_breakdown()`` internally. Note that
+                calling ``FinancialCalculator.calculate_npv()`` directly does
+                not respect per-asset overrides.
+                Default: 5%.
+            round_up_replacement: If True (default), NPV, LCOE, and TCO use
+                ``ceil`` for the asset replacement count — the financially exact
+                calculation. If False, uses the continuous factor
+                ``max(1, system_lifetime / technical_lifetime)`` for
+                compatibility with MESIDO optimizer output. Only set this to
+                False when comparing results against MESIDO.
 
         Returns:
-            Dictionary with all KPI results.
+            ``KpiResults`` dict with ``financials``, ``energy``, ``emissions``,
+            and ``asset_financials`` keys.
         """
         if not self.energy_system:
             raise ValueError("No energy system loaded. Call one of the load methods first.")
@@ -255,6 +313,17 @@ class KpiManager:
 
         return results
 
+    def _warn_if_level_not_system(self, level: str) -> None:
+        """Emit a warning when a non-system export level is requested.
+
+        Area-level and asset-level KPI placement are not yet implemented;
+        all levels currently fall back to system-wide export.
+        """
+        if level != "system":
+            _logger.warning(
+                "KPI export level '%s' is not yet implemented; falling back to 'system'.", level
+            )
+
     def export_to_esdl(
         self, results: KpiResults, output_file: str | None = None, level: str = "system"
     ) -> bool | esdl.EnergySystem:
@@ -263,7 +332,9 @@ class KpiManager:
         Args:
             results: KPI calculation results from calculate_all_kpis()
             output_file: Output ESDL file path. If None, returns data structure.
-            level: KPI level ('system', 'area', 'asset')
+            level: KPI granularity — ``'system'``, ``'area'``, or ``'asset'``.
+                Currently all levels write system-wide KPIs to the main area;
+                area-level and asset-level placement are not yet implemented.
 
         Returns:
             bool: True if file export succeeded (when output_file provided)
@@ -274,6 +345,8 @@ class KpiManager:
         """
         if not self.energy_system:
             raise ValueError("No energy system loaded. Call one of the load methods first.")
+
+        self._warn_if_level_not_system(level)
 
         from .reporting.esdl_kpi_exporter import EsdlKpiExporter
 
@@ -291,7 +364,9 @@ class KpiManager:
 
         Args:
             results: KPI calculation results from calculate_all_kpis()
-            level: KPI level ('system', 'area', 'asset')
+            level: KPI granularity — ``'system'``, ``'area'``, or ``'asset'``.
+                Currently all levels write system-wide KPIs to the main area;
+                area-level and asset-level placement are not yet implemented.
 
         Returns:
             esdl.EnergySystem: ESDL data structure with KPIs
@@ -316,7 +391,9 @@ class KpiManager:
         Args:
             esdl_string: Input ESDL XML string to embed KPIs into.
             results: KPI calculation results from calculate_all_kpis()
-            level: KPI level ('system', 'area', 'asset')
+            level: KPI granularity — ``'system'``, ``'area'``, or ``'asset'``.
+                Currently all levels write system-wide KPIs to the main area;
+                area-level and asset-level placement are not yet implemented.
 
         Returns:
             ESDL XML string with KPIs embedded.
@@ -329,6 +406,8 @@ class KpiManager:
             raise ValueError("No energy system loaded. Call one of the load methods first.")
         if not esdl_string.strip():
             raise ValueError("esdl_string must not be empty.")
+
+        self._warn_if_level_not_system(level)
 
         from esdl.esdl_handler import EnergySystemHandler
 

--- a/src/kpicalculator/kpi_manager.py
+++ b/src/kpicalculator/kpi_manager.py
@@ -8,7 +8,7 @@ from esdl import esdl
 from .adapters.common_model import EnergySystem
 from .adapters.esdl_adapter import EsdlAdapter
 from .adapters.simulator_adapter import SimulatorAdapter
-from .common.constants import DEFAULT_SYSTEM_LIFETIME_YEARS
+from .common.constants import DEFAULT_DISCOUNT_RATE_PERCENT, DEFAULT_SYSTEM_LIFETIME_YEARS
 
 _logger = logging.getLogger(__name__)
 
@@ -20,6 +20,8 @@ class CostResults(TypedDict):
     opex: dict[str, float]
     npv: float
     lcoe: float
+    eac: float
+    tco: float
 
 
 class EnergyResults(TypedDict):
@@ -145,18 +147,34 @@ class KpiManager:
         raise NotImplementedError("Mesido adapter not implemented yet")
 
     def calculate_all_kpis(
-        self, system_lifetime: float = DEFAULT_SYSTEM_LIFETIME_YEARS
+        self,
+        system_lifetime: float = DEFAULT_SYSTEM_LIFETIME_YEARS,
+        discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT,
+        round_up_replacement: bool = True,
     ) -> KpiResults:
         """Calculate all KPIs for the energy system.
 
+        Raises:
+            ValueError: If no energy system is loaded, ``system_lifetime <= 0``,
+                or ``discount_rate`` is outside [0, 100].
+
         Args:
-            system_lifetime: System lifetime in years
+            system_lifetime: System lifetime in years. Must be positive.
+            discount_rate: Discount rate in percentage (e.g. 5 for 5%). Must be in [0, 100].
+            round_up_replacement: If True (default), NPV, LCOE, and TCO use ``ceil``
+                for the asset replacement count (financially exact). If False, uses the
+                continuous factor ``max(1, n / technical_lifetime)`` for optimizer
+                compatibility.
 
         Returns:
-            Dictionary with all KPI results
+            Dictionary with all KPI results.
         """
         if not self.energy_system:
             raise ValueError("No energy system loaded. Call one of the load methods first.")
+        if system_lifetime <= 0:
+            raise ValueError(f"system_lifetime must be positive (got {system_lifetime}).")
+        if discount_rate < 0 or discount_rate > 100:
+            raise ValueError(f"discount_rate must be between 0 and 100 (got {discount_rate}).")
 
         from .calculators.cost_calculator import CostCalculator
         from .calculators.emission_calculator import EmissionCalculator
@@ -170,8 +188,17 @@ class KpiManager:
             "costs": {
                 "capex": cost_calc.get_capex_by_category(),
                 "opex": cost_calc.get_opex_by_category(),
-                "npv": cost_calc.calculate_npv(system_lifetime),
-                "lcoe": cost_calc.calculate_lcoe(system_lifetime),
+                "npv": cost_calc.calculate_npv(
+                    system_lifetime, discount_rate, round_up_replacement=round_up_replacement
+                ),
+                "lcoe": cost_calc.calculate_lcoe(
+                    system_lifetime, discount_rate, round_up_replacement=round_up_replacement
+                ),
+                "eac": cost_calc.calculate_eac(discount_rate),
+                # TCO is intentionally undiscounted — discount_rate is not used.
+                "tco": cost_calc.calculate_tco(
+                    system_lifetime, round_up_replacement=round_up_replacement
+                ),
             },
             "energy": {
                 "consumption": energy_calc.get_total_energy_consumption_per_year(),

--- a/src/kpicalculator/kpi_manager.py
+++ b/src/kpicalculator/kpi_manager.py
@@ -204,7 +204,7 @@ class KpiManager:
         # TODO: Implement mesido adapter
         raise NotImplementedError("Mesido adapter not implemented yet")
 
-    def calculate_all_kpis(
+    def calculate_all_kpis(  # pylint: disable=too-many-locals
         self,
         system_lifetime: float = DEFAULT_SYSTEM_LIFETIME_YEARS,
         discount_rate: float = DEFAULT_DISCOUNT_RATE_PERCENT,
@@ -218,7 +218,7 @@ class KpiManager:
 
         Args:
             system_lifetime: System lifetime in years. Must be positive.
-                Default: 30 years.
+                Default: ``DEFAULT_SYSTEM_LIFETIME_YEARS``.
             discount_rate: System-wide fallback discount rate in percentage
                 (e.g. 5 for 5%). Must be in [0, 100]. Individual assets may
                 override this via ``costInformation.discountRate`` in the ESDL
@@ -226,7 +226,7 @@ class KpiManager:
                 ``get_asset_financial_breakdown()`` internally. Note that
                 calling ``FinancialCalculator.calculate_npv()`` directly does
                 not respect per-asset overrides.
-                Default: 5%.
+                Default: ``DEFAULT_DISCOUNT_RATE_PERCENT``.
             round_up_replacement: If True (default), NPV, LCOE, and TCO use
                 ``ceil`` for the asset replacement count — the financially exact
                 calculation. If False, uses the continuous factor
@@ -345,18 +345,23 @@ class KpiManager:
         """
         if not self.energy_system:
             raise ValueError("No energy system loaded. Call one of the load methods first.")
+        if self.energy_system.esdl_energy_system is None:
+            raise ValueError(
+                "No ESDL object available; the loaded adapter did not store one "
+                "(e.g. load_from_simulator). Use load_from_esdl() or "
+                "load_from_esdl_string(), or use build_esdl_string_with_kpis() "
+                "to embed KPIs into an ESDL string without a loaded manager."
+            )
 
         self._warn_if_level_not_system(level)
 
         from .reporting.esdl_kpi_exporter import EsdlKpiExporter
 
-        exporter = EsdlKpiExporter()
-        return exporter.export(
+        return EsdlKpiExporter().export(
             results,
-            self.energy_system,
+            self.energy_system.esdl_energy_system,
             output_file,
             level=level,
-            source_esdl_file=self.source_esdl_file,
         )
 
     def build_esdl_with_kpis(self, results: KpiResults, level: str = "system") -> esdl.EnergySystem:
@@ -385,8 +390,9 @@ class KpiManager:
         """Embed KPI results into an ESDL XML string and return the updated string.
 
         This is the preferred integration method for systems that work with ESDL
-        strings (e.g. simulator-worker). It avoids the need to manipulate internal
-        adapter state and produces a self-contained output string.
+        strings (e.g. simulator-worker). It operates entirely on a local
+        ``EnergySystemHandler`` parsed from ``esdl_string`` and does not modify
+        any manager state, making it safe to call repeatedly on the same instance.
 
         Args:
             esdl_string: Input ESDL XML string to embed KPIs into.
@@ -399,11 +405,8 @@ class KpiManager:
             ESDL XML string with KPIs embedded.
 
         Raises:
-            ValueError: If no energy system is loaded, esdl_string is empty,
-                or invalid parameters are provided.
+            ValueError: If esdl_string is empty or invalid parameters are provided.
         """
-        if not self.energy_system:
-            raise ValueError("No energy system loaded. Call one of the load methods first.")
         if not esdl_string.strip():
             raise ValueError("esdl_string must not be empty.")
 
@@ -415,18 +418,7 @@ class KpiManager:
 
         esh = EnergySystemHandler()
         esh.load_from_string(esdl_string)
-
-        # Redirect the exporter to the target ESDL object tree so KPIs are written
-        # into the correct output. Safe because the exporter reads this attribute
-        # once into a local variable; try/finally restores the original reference.
-        original_esdl_energy_system = self.energy_system.esdl_energy_system
-        self.energy_system.esdl_energy_system = esh.energy_system
-        try:
-            exporter = EsdlKpiExporter()
-            exporter.export(results, self.energy_system, destination=None, level=level)
-        finally:
-            self.energy_system.esdl_energy_system = original_esdl_energy_system
-
+        EsdlKpiExporter().export(results, esh.energy_system, destination=None, level=level)
         return cast(str, esh.to_string())
 
 

--- a/src/kpicalculator/reporting/base_exporter.py
+++ b/src/kpicalculator/reporting/base_exporter.py
@@ -4,7 +4,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
 
-from ..adapters.common_model import EnergySystem
+from esdl import esdl
+
 from ..kpi_manager import KpiResults
 
 
@@ -15,21 +16,21 @@ class BaseExporter(ABC):
     def export(
         self,
         results: KpiResults,
-        energy_system: EnergySystem,
+        esdl_energy_system: esdl.EnergySystem,
         destination: str | Path | None = None,
     ) -> bool | Any:
         """Export KPI results to specified destination.
 
         Args:
-            results: KPI calculation results
-            energy_system: Energy system with metadata
+            results: KPI calculation results.
+            esdl_energy_system: Parsed PyESDL energy system object to write KPIs into.
             destination: Export destination (file path, etc.). If None, return data structure.
 
         Returns:
-            bool: True if file export succeeded, False otherwise
-            Any: Data structure if destination is None
+            bool: True if file export succeeded.
+            Any: Data structure if destination is None.
 
         Raises:
-            ValueError: If required parameters are missing or invalid
+            ValueError: If required parameters are missing or invalid.
         """
         ...

--- a/src/kpicalculator/reporting/esdl_kpi_exporter.py
+++ b/src/kpicalculator/reporting/esdl_kpi_exporter.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from esdl import esdl
 from esdl.esdl_handler import EnergySystemHandler
 
-from ..adapters.common_model import EnergySystem
 from ..common.constants import TONS_TO_GRAMS
 from ..kpi_manager import EmissionResults, EnergyResults, FinancialResults, KpiResults
 from .base_exporter import BaseExporter
@@ -27,6 +26,11 @@ class EsdlKpiExporter(BaseExporter):
 
     Note: This exporter does NOT perform any calculations. All KPI values must be
     pre-calculated by the appropriate calculator classes.
+
+    .. note::
+        This is an internal class, not part of the public API. Use
+        :meth:`KpiManager.export_to_esdl`, :meth:`KpiManager.build_esdl_string_with_kpis`,
+        or the top-level :func:`kpicalculator.build_esdl_string_with_kpis` instead.
     """
 
     def __init__(self) -> None:
@@ -36,10 +40,9 @@ class EsdlKpiExporter(BaseExporter):
     def export(
         self,
         results: KpiResults,
-        energy_system: EnergySystem,
+        esdl_energy_system: esdl.EnergySystem,
         destination: str | Path | None = None,
         level: str = "system",
-        source_esdl_file: str | Path | None = None,
     ) -> bool | esdl.EnergySystem:
         """Export pre-calculated KPI results to ESDL format.
 
@@ -49,68 +52,42 @@ class EsdlKpiExporter(BaseExporter):
 
         Args:
             results: Pre-calculated KPI results from cost/energy/emission calculators.
-                Must contain 'costs', 'energy', and 'emissions' dictionaries with
-                calculated values (no calculations performed by this method).
-            energy_system: Energy system with source metadata for ESDL file location.
+            esdl_energy_system: Parsed PyESDL energy system object to write KPIs into.
             destination: Output ESDL file path. If None, returns data structure instead.
             level: KPI integration level - 'system' (main area), 'area' (per area),
                 or 'asset' (per asset). Currently 'area' and 'asset' delegate to 'system'.
-            source_esdl_file: Explicit path to source ESDL file. Used only when
-                energy_system.esdl_energy_system is None. Resolution order:
-                (1) energy_system.esdl_energy_system (preferred, avoids disk I/O),
-                (2) this parameter, (3) energy_system.source_metadata['esdl_file'].
 
         Returns:
             When destination provided: Always True on success; raises on failure.
-            When destination is None: esdl.EnergySystem object with integrated KPIs
+            When destination is None: esdl.EnergySystem object with integrated KPIs.
 
         Raises:
-            ValueError: If level is invalid, results structure is malformed,
-                or source ESDL file cannot be determined or loaded.
+            ValueError: If esdl_energy_system is None, level is invalid, or
+                results structure is malformed.
             OSError: If file operations fail during save.
         """
-        # Validate level parameter
+        if esdl_energy_system is None:
+            raise ValueError(
+                "esdl_energy_system must not be None. "
+                "Use KpiManager.export_to_esdl() or build_esdl_string_with_kpis() instead."
+            )
         valid_levels = ["system", "area", "asset"]
         if level not in valid_levels:
             raise ValueError(f"Invalid KPI level '{level}'. Must be one of: {valid_levels}")
 
-        # KPI results structure is validated by TypedDict at runtime
-
-        esdl_system = energy_system.esdl_energy_system
-
-        if esdl_system is None:
-            esdl_file = source_esdl_file
-            if not esdl_file and energy_system.source_metadata:
-                esdl_file = energy_system.source_metadata.get("esdl_file")
-
-            if not esdl_file:
-                raise ValueError(
-                    "Cannot export KPIs: No stored ESDL object and no source ESDL "
-                    "file provided. Either load via EsdlAdapter (which stores the "
-                    "ESDL object) or provide source_esdl_file parameter."
-                )
-
-            esdl_system = self.handler.load_file(esdl_file)
-
-        # Add KPIs to the appropriate level
         if level == "system":
-            self._add_kpis_to_system(esdl_system, results)
+            self._add_kpis_to_system(esdl_energy_system, results)
         elif level == "area":
-            self._add_kpis_to_areas(esdl_system, results)
+            self._add_kpis_to_areas(esdl_energy_system, results)
         elif level == "asset":
-            self._add_kpis_to_assets(esdl_system, results)
+            self._add_kpis_to_assets(esdl_energy_system, results)
 
-        # Export or return based on destination
         if destination is not None:
-            # File mode - save to disk and return True on success.
-            # Exceptions (OSError, etc.) propagate to the caller so they
-            # can inspect the actual failure instead of just receiving False.
-            self.handler.energy_system = esdl_system
+            self.handler.energy_system = esdl_energy_system
             self.handler.save(destination)
             return True
 
-        # Data structure mode - return ESDL object
-        return esdl_system
+        return esdl_energy_system
 
     def _add_kpis_to_system(self, esdl_system: esdl.EnergySystem, results: KpiResults) -> None:
         """Add system-level KPIs to the main area of the ESDL energy system.

--- a/src/kpicalculator/reporting/esdl_kpi_exporter.py
+++ b/src/kpicalculator/reporting/esdl_kpi_exporter.py
@@ -210,6 +210,22 @@ class EsdlKpiExporter(BaseExporter):
             )
             kpis.kpi.append(kpi)
 
+        # EAC KPI
+        if "eac" in cost_data:
+            items = [("EAC", cost_data["eac"])]
+            kpi = self._create_distribution_kpi(
+                "Equivalent Annual Cost [EUR/yr]", "COST", "EURO", items, per_unit="YEAR"
+            )
+            kpis.kpi.append(kpi)
+
+        # TCO KPI
+        if "tco" in cost_data:
+            items = [("TCO", cost_data["tco"])]
+            kpi = self._create_distribution_kpi(
+                "Total Cost of Ownership [EUR]", "COST", "EURO", items
+            )
+            kpis.kpi.append(kpi)
+
     def _add_energy_kpis(self, kpis: esdl.KPIs, energy_data: EnergyResults) -> None:
         """Add energy-related KPIs to the ESDL KPIs container.
 

--- a/src/kpicalculator/reporting/esdl_kpi_exporter.py
+++ b/src/kpicalculator/reporting/esdl_kpi_exporter.py
@@ -173,30 +173,30 @@ class EsdlKpiExporter(BaseExporter):
             )
             kpis.kpi.append(kpi)
 
-        # NPV KPI
-        if "npv" in cost_data:
+        # NPV KPI — omit when zero (means no cost data was available in the ESDL)
+        if "npv" in cost_data and cost_data["npv"] != 0.0:
             items = [("NPV", cost_data["npv"])]
             kpi = self._create_distribution_kpi("Net Present Value [EUR]", "COST", "EURO", items)
             kpis.kpi.append(kpi)
 
-        # LCOE KPI
-        if "lcoe" in cost_data:
+        # LCOE KPI — omit when zero (means energy consumption data was unavailable)
+        if "lcoe" in cost_data and cost_data["lcoe"] != 0.0:
             items = [("LCOE", cost_data["lcoe"])]
             kpi = self._create_distribution_kpi(
                 "Levelized Cost of Energy [EUR/MWh]", "COST", "EURO", items, per_unit="WATTHOUR"
             )
             kpis.kpi.append(kpi)
 
-        # EAC KPI
-        if "eac" in cost_data:
+        # EAC KPI — omit when zero (means no cost data was available in the ESDL)
+        if "eac" in cost_data and cost_data["eac"] != 0.0:
             items = [("EAC", cost_data["eac"])]
             kpi = self._create_distribution_kpi(
                 "Equivalent Annual Cost [EUR/yr]", "COST", "EURO", items, per_unit="YEAR"
             )
             kpis.kpi.append(kpi)
 
-        # TCO KPI
-        if "tco" in cost_data:
+        # TCO KPI — omit when zero (means no cost data was available in the ESDL)
+        if "tco" in cost_data and cost_data["tco"] != 0.0:
             items = [("TCO", cost_data["tco"])]
             kpi = self._create_distribution_kpi(
                 "Total Cost of Ownership [EUR]", "COST", "EURO", items
@@ -214,13 +214,13 @@ class EsdlKpiExporter(BaseExporter):
             energy_data: Pre-calculated energy results with consumption, production, demand,
                 efficiency
         """
-        # Energy breakdown
+        # Energy breakdown — only include non-zero values (zero means no time series matched)
         energy_items = []
-        if "consumption" in energy_data:
+        if "consumption" in energy_data and energy_data["consumption"] != 0.0:
             energy_items.append(("Consumption", energy_data["consumption"]))
-        if "production" in energy_data:
+        if "production" in energy_data and energy_data["production"] != 0.0:
             energy_items.append(("Production", energy_data["production"]))
-        if "demand" in energy_data:
+        if "demand" in energy_data and energy_data["demand"] != 0.0:
             energy_items.append(("Demand", energy_data["demand"]))
 
         if energy_items:
@@ -229,8 +229,8 @@ class EsdlKpiExporter(BaseExporter):
             )
             kpis.kpi.append(kpi)
 
-        # Energy efficiency
-        if "efficiency" in energy_data:
+        # Energy efficiency — omit when zero (means production data was unavailable)
+        if "efficiency" in energy_data and energy_data["efficiency"] != 0.0:
             items = [("System Efficiency", energy_data["efficiency"])]
             kpi = self._create_distribution_kpi("Energy efficiency [-]", "ENERGY", "NONE", items)
             kpis.kpi.append(kpi)
@@ -245,16 +245,16 @@ class EsdlKpiExporter(BaseExporter):
             kpis: ESDL KPIs container to add emission KPIs to
             emission_data: Pre-calculated emission results with total and per_mwh values
         """
-        # Total emissions
-        if "total" in emission_data:
+        # Total emissions — omit when zero (means no emission factors in ESDL carriers)
+        if "total" in emission_data and emission_data["total"] != 0.0:
             # Convert to grams for ESDL
             total_grams = emission_data["total"] * TONS_TO_GRAMS
             items = [("Total CO2 Emissions", total_grams)]
             kpi = self._create_distribution_kpi("CO2 emissions [g]", "EMISSION", "GRAM", items)
             kpis.kpi.append(kpi)
 
-        # Emissions per MWh
-        if "per_mwh" in emission_data:
+        # Emissions per MWh — omit when zero (means no emission factors or no energy data)
+        if "per_mwh" in emission_data and emission_data["per_mwh"] != 0.0:
             # Convert to g/MWh
             per_mwh_grams = emission_data["per_mwh"] * TONS_TO_GRAMS
             items = [("CO2 per MWh", per_mwh_grams)]

--- a/src/kpicalculator/reporting/esdl_kpi_exporter.py
+++ b/src/kpicalculator/reporting/esdl_kpi_exporter.py
@@ -9,7 +9,7 @@ from esdl.esdl_handler import EnergySystemHandler
 
 from ..adapters.common_model import EnergySystem
 from ..common.constants import TONS_TO_GRAMS
-from ..kpi_manager import CostResults, EmissionResults, EnergyResults, KpiResults
+from ..kpi_manager import EmissionResults, EnergyResults, FinancialResults, KpiResults
 from .base_exporter import BaseExporter
 
 logger = logging.getLogger(__name__)
@@ -139,8 +139,8 @@ class EsdlKpiExporter(BaseExporter):
             main_area.KPIs.kpi.clear()
 
         # Add KPIs by category
-        if "costs" in results:
-            self._add_cost_kpis(main_area.KPIs, results["costs"])
+        if "financials" in results:
+            self._add_financial_kpis(main_area.KPIs, results["financials"])
         if "energy" in results:
             self._add_energy_kpis(main_area.KPIs, results["energy"])
         if "emissions" in results:
@@ -172,15 +172,15 @@ class EsdlKpiExporter(BaseExporter):
         # For now, add to main area - can be extended for per-asset results
         self._add_kpis_to_system(esdl_system, results)
 
-    def _add_cost_kpis(self, kpis: esdl.KPIs, cost_data: CostResults) -> None:
-        """Add cost-related KPIs to the ESDL KPIs container.
+    def _add_financial_kpis(self, kpis: esdl.KPIs, cost_data: FinancialResults) -> None:
+        """Add financial KPIs to the ESDL KPIs container.
 
-        Creates DistributionKPI elements for cost breakdowns, NPV, and LCOE using
-        pre-calculated values from the cost calculator. Does not perform calculations.
+        Creates DistributionKPI elements for CAPEX/OPEX breakdowns, NPV, LCOE, EAC,
+        and TCO using pre-calculated values. Does not perform calculations.
 
         Args:
-            kpis: ESDL KPIs container to add cost KPIs to
-            cost_data: Pre-calculated cost results with 'capex', 'opex', 'npv', 'lcoe'
+            kpis: ESDL KPIs container to add financial KPIs to
+            cost_data: Pre-calculated financial results with 'capex', 'opex', 'npv', 'lcoe'
         """
 
         # High level cost breakdown (using pre-calculated values)

--- a/unit_test/test_api.py
+++ b/unit_test/test_api.py
@@ -48,20 +48,22 @@ class TestCalculateKpisHappyPath(unittest.TestCase):
         """
         results = calculate_kpis(ESDL_FILE)
 
-        self.assertIn("costs", results)
+        self.assertIn("financials", results)
         self.assertIn("energy", results)
         self.assertIn("emissions", results)
-        self.assertIn("capex", results["costs"])
-        self.assertIn("opex", results["costs"])
-        self.assertIn("npv", results["costs"])
-        self.assertIn("lcoe", results["costs"])
+        self.assertIn("capex", results["financials"])
+        self.assertIn("opex", results["financials"])
+        self.assertIn("npv", results["financials"])
+        self.assertIn("lcoe", results["financials"])
 
     def test_accepts_path_object(self) -> None:
         """calculate_kpis() accepts a pathlib.Path as well as a string for esdl_file."""
         results_from_path = calculate_kpis(ESDL_FILE)
         results_from_str = calculate_kpis(str(ESDL_FILE))
 
-        self.assertEqual(results_from_path["costs"]["npv"], results_from_str["costs"]["npv"])
+        self.assertEqual(
+            results_from_path["financials"]["npv"], results_from_str["financials"]["npv"]
+        )
 
     def test_with_xml_time_series(self) -> None:
         """calculate_kpis() loads XML time series when the time_series argument is provided.
@@ -72,7 +74,10 @@ class TestCalculateKpisHappyPath(unittest.TestCase):
         results = calculate_kpis(ESDL_FILE, time_series=TIME_SERIES_FILE)
 
         energy = results["energy"]
-        self.assertGreater(energy["consumption"] + energy["production"], 0.0)
+        # The fixture time series has consumption data; verify consumption specifically.
+        self.assertGreater(
+            energy["consumption"], 0.0, "energy consumption must be > 0 with time series"
+        )
 
     def test_with_dataframes(self) -> None:
         """calculate_kpis() with timeseries_dataframes routes data to the energy calculator.
@@ -109,7 +114,7 @@ class TestCalculateKpisHappyPath(unittest.TestCase):
         results_short = calculate_kpis(ESDL_FILE, system_lifetime=10.0)
 
         # NPV over 10 years must be less than NPV over 30 years (default)
-        self.assertLess(results_short["costs"]["npv"], results_default["costs"]["npv"])
+        self.assertLess(results_short["financials"]["npv"], results_default["financials"]["npv"])
 
 
 class TestCalculateKpisErrorHandling(unittest.TestCase):

--- a/unit_test/test_esdl_cost_extraction.py
+++ b/unit_test/test_esdl_cost_extraction.py
@@ -325,7 +325,7 @@ class TestApiCostExtraction(unittest.TestCase):
         )
 
         # Verify results structure
-        self.assertIn("costs", results)
+        self.assertIn("financials", results)
         self.assertIn("energy", results)
         self.assertIn("emissions", results)
 

--- a/unit_test/test_esdl_kpi_exporter.py
+++ b/unit_test/test_esdl_kpi_exporter.py
@@ -199,7 +199,9 @@ class TestEsdlKpiExporter(unittest.TestCase):
 
             # Assert
             self.assertTrue(result)
-            self.assertTrue(Path(output_file).exists(), f"Output file {output_file} was not created.")
+            self.assertTrue(
+                Path(output_file).exists(), f"Output file {output_file} was not created."
+            )
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
     def test_export_data_structure_mode(self, mock_handler):

--- a/unit_test/test_esdl_kpi_exporter.py
+++ b/unit_test/test_esdl_kpi_exporter.py
@@ -153,13 +153,11 @@ class TestEsdlKpiExporter(unittest.TestCase):
         )
         self.assertEqual(emission_kpi.quantityAndUnit.unit, esdl.UnitEnum.GRAM)
 
-    @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
-    def test_export_file_mode(self, mock_handler):
+    def test_export_file_mode(self):
         """Test export method in file mode saves to disk and returns True."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
         mock_esdl_system = self.create_mock_esdl_system()
-        mock_handler_instance = mock_handler.return_value
         output_file = f"{self.test_temp_dir}/test_output.esdl"
 
         exporter = EsdlKpiExporter()
@@ -168,7 +166,8 @@ class TestEsdlKpiExporter(unittest.TestCase):
         )
 
         self.assertTrue(result)
-        mock_handler_instance.save.assert_called_once_with(output_file)
+        # Check that the file was actually created
+        self.assertTrue(Path(output_file).exists(), f"Output file {output_file} was not created.")
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
     def test_export_data_structure_mode(self, mock_handler):
@@ -244,6 +243,92 @@ class TestEsdlKpiExporter(unittest.TestCase):
         kpi_count_2 = len(mock_esdl_system.instance[0].area.KPIs.kpi)
 
         self.assertEqual(kpi_count_1, kpi_count_2, "Repeated export should not accumulate KPIs")
+
+
+class TestEsdlKpiExporterSkipZero(unittest.TestCase):
+    """Test that KPI elements with zero (missing-data) values are omitted from ESDL output."""
+
+    def _make_system(self) -> esdl.EnergySystem:
+        energy_system = esdl.EnergySystem()
+        energy_system.id = "s"
+        instance = esdl.Instance()
+        instance.id = "i"
+        area = esdl.Area()
+        area.id = "a"
+        instance.area = area
+        energy_system.instance.append(instance)
+        return energy_system
+
+    def _export(self, results: dict) -> dict:
+        from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
+
+        es = self._make_system()
+        exported = EsdlKpiExporter().export(results, es, destination=None, level="system")
+        assert isinstance(exported, esdl.EnergySystem)
+        return {kpi.name: kpi for kpi in exported.instance[0].area.KPIs.kpi}
+
+    def test__zero_npv__omits_npv_kpi(self) -> None:
+        results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "npv": 0.0}}
+        kpi_by_name = self._export(results)
+        self.assertNotIn("Net Present Value [EUR]", kpi_by_name)
+
+    def test__nonzero_npv__includes_npv_kpi(self) -> None:
+        results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "npv": 5000.0}}
+        kpi_by_name = self._export(results)
+        self.assertIn("Net Present Value [EUR]", kpi_by_name)
+
+    def test__zero_lcoe__omits_lcoe_kpi(self) -> None:
+        results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "lcoe": 0.0}}
+        kpi_by_name = self._export(results)
+        self.assertNotIn("Levelized Cost of Energy [EUR/MWh]", kpi_by_name)
+
+    def test__nonzero_lcoe__includes_lcoe_kpi(self) -> None:
+        results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "lcoe": 0.05}}
+        kpi_by_name = self._export(results)
+        self.assertIn("Levelized Cost of Energy [EUR/MWh]", kpi_by_name)
+
+    def test__zero_eac__omits_eac_kpi(self) -> None:
+        results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "eac": 0.0}}
+        kpi_by_name = self._export(results)
+        self.assertNotIn("Equivalent Annual Cost [EUR/yr]", kpi_by_name)
+
+    def test__zero_tco__omits_tco_kpi(self) -> None:
+        results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "tco": 0.0}}
+        kpi_by_name = self._export(results)
+        self.assertNotIn("Total Cost of Ownership [EUR]", kpi_by_name)
+
+    def test__zero_energy_values__omits_energy_breakdown_kpi(self) -> None:
+        results = {"energy": {"consumption": 0.0, "production": 0.0, "demand": 0.0}}
+        kpi_by_name = self._export(results)
+        self.assertNotIn("Energy breakdown [Wh]", kpi_by_name)
+
+    def test__nonzero_production_only__includes_energy_breakdown(self) -> None:
+        results = {"energy": {"consumption": 0.0, "production": 1e9, "demand": 0.0}}
+        kpi_by_name = self._export(results)
+        self.assertIn("Energy breakdown [Wh]", kpi_by_name)
+        items = {
+            item.label: item.value
+            for item in kpi_by_name["Energy breakdown [Wh]"].distribution.stringItem
+        }
+        self.assertNotIn("Consumption", items)
+        self.assertIn("Production", items)
+
+    def test__zero_efficiency__omits_efficiency_kpi(self) -> None:
+        results = {"energy": {"efficiency": 0.0}}
+        kpi_by_name = self._export(results)
+        self.assertNotIn("Energy efficiency [-]", kpi_by_name)
+
+    def test__zero_emissions__omits_co2_kpis(self) -> None:
+        results = {"emissions": {"total": 0.0, "per_mwh": 0.0}}
+        kpi_by_name = self._export(results)
+        self.assertNotIn("CO2 emissions [g]", kpi_by_name)
+        self.assertNotIn("CO2 emissions per MWh [g/MWh]", kpi_by_name)
+
+    def test__nonzero_emissions__includes_co2_kpis(self) -> None:
+        results = {"emissions": {"total": 500.0, "per_mwh": 1.2}}
+        kpi_by_name = self._export(results)
+        self.assertIn("CO2 emissions [g]", kpi_by_name)
+        self.assertIn("CO2 emissions per MWh [g/MWh]", kpi_by_name)
 
 
 if __name__ == "__main__":

--- a/unit_test/test_esdl_kpi_exporter.py
+++ b/unit_test/test_esdl_kpi_exporter.py
@@ -3,7 +3,7 @@
 import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from esdl import esdl
 
@@ -13,7 +13,6 @@ class TestEsdlKpiExporter(unittest.TestCase):
 
     def setUp(self) -> None:
         """Set up test environment with mock data."""
-        # Mock KPI results structure
         self.mock_kpi_results = {
             "financials": {
                 "capex": {"All": 100000.0, "Producer": 60000.0, "Consumer": 40000.0},
@@ -30,12 +29,6 @@ class TestEsdlKpiExporter(unittest.TestCase):
             "emissions": {"total": 1200.0, "per_mwh": 2.4},
         }
 
-        # Mock energy system with source metadata
-        self.mock_energy_system = Mock()
-        self.mock_energy_system.source_metadata = {"esdl_file": "test_input.esdl"}
-        self.mock_energy_system.esdl_energy_system = None
-
-        # Create temporary directory for test outputs
         self.test_temp_dir = tempfile.mkdtemp(prefix="esdl_exporter_test_")
 
     def tearDown(self) -> None:
@@ -45,24 +38,20 @@ class TestEsdlKpiExporter(unittest.TestCase):
         if Path(self.test_temp_dir).exists():
             shutil.rmtree(self.test_temp_dir)
 
-    def create_mock_esdl_system(self):
-        """Create a mock ESDL energy system for testing."""
-        # Create basic ESDL structure
+    def create_mock_esdl_system(self) -> esdl.EnergySystem:
+        """Create a minimal mock ESDL energy system for testing."""
         energy_system = esdl.EnergySystem()
         energy_system.id = "test-system"
         energy_system.name = "Test System"
 
-        # Create instance
         instance = esdl.Instance()
         instance.id = "test-instance"
         instance.name = "Test Instance"
 
-        # Create area
         area = esdl.Area()
         area.id = "test-area"
         area.name = "Test Area"
 
-        # Assemble structure
         instance.area = area
         energy_system.instance.append(instance)
 
@@ -74,32 +63,18 @@ class TestEsdlKpiExporter(unittest.TestCase):
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
         exporter = EsdlKpiExporter()
-
-        # Test data
-        name = "Test KPI [EUR] (yearly averaged)"
-        physical_quantity = "COST"
-        unit = "EURO"
         items = [("CAPEX", 5000.0), ("OPEX", 3000.0)]
+        kpi = exporter._create_distribution_kpi("Test KPI [EUR]", "COST", "EURO", items)
 
-        # Create distribution KPI
-        kpi = exporter._create_distribution_kpi(name, physical_quantity, unit, items)
-
-        # Verify structure
         self.assertIsInstance(kpi, esdl.DistributionKPI)
-        self.assertEqual(kpi.name, name)
+        self.assertEqual(kpi.name, "Test KPI [EUR]")
         self.assertIsNotNone(kpi.id)
-
-        # Verify quantity and unit
         self.assertIsNotNone(kpi.quantityAndUnit)
         self.assertEqual(kpi.quantityAndUnit.physicalQuantity, esdl.PhysicalQuantityEnum.COST)
         self.assertEqual(kpi.quantityAndUnit.unit, esdl.UnitEnum.EURO)
-
-        # Verify distribution
         self.assertIsNotNone(kpi.distribution)
         self.assertIsInstance(kpi.distribution, esdl.StringLabelDistribution)
         self.assertEqual(len(kpi.distribution.stringItem), 2)
-
-        # Verify string items
         for i, (expected_label, expected_value) in enumerate(items):
             item = kpi.distribution.stringItem[i]
             self.assertEqual(item.label, expected_label)
@@ -107,97 +82,71 @@ class TestEsdlKpiExporter(unittest.TestCase):
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
     def test_add_financial_kpis(self, _mock_handler):
-        """Test _add_financial_kpis method adds correct cost KPI structure."""
+        """Test _add_financial_kpis adds correct cost KPI structure."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
         exporter = EsdlKpiExporter()
-
-        # Create KPIs container
         kpis = esdl.KPIs()
         kpis.id = "test-kpis"
 
-        # Add cost KPIs
         exporter._add_financial_kpis(kpis, self.mock_kpi_results["financials"])
 
-        # Verify KPIs were added
-        self.assertGreater(len(kpis.kpi), 0, "Should add cost KPIs")
-
-        # Find and verify high level cost breakdown
+        self.assertGreater(len(kpis.kpi), 0)
         high_level_kpis = [kpi for kpi in kpis.kpi if "High level cost breakdown" in kpi.name]
-        self.assertGreater(len(high_level_kpis), 0, "Should contain high level cost breakdown KPIs")
+        self.assertGreater(len(high_level_kpis), 0)
 
-        # Verify cost breakdown KPI
         cost_kpi = high_level_kpis[0]
-        # Check CAPEX and OPEX values
         capex_item = next(
             (item for item in cost_kpi.distribution.stringItem if "CAPEX" in item.label), None
         )
         opex_item = next(
             (item for item in cost_kpi.distribution.stringItem if "OPEX" in item.label), None
         )
-
         self.assertIsNotNone(capex_item, "Should contain CAPEX item")
         self.assertIsNotNone(opex_item, "Should contain OPEX item")
 
-        # Verify values (use pre-calculated values from cost calculator)
         expected_capex = self.mock_kpi_results["financials"]["capex"]["All"]
         expected_opex = self.mock_kpi_results["financials"]["opex"]["All"]
-
         self.assertAlmostEqual(float(capex_item.value), expected_capex, places=2)
         self.assertAlmostEqual(float(opex_item.value), expected_opex, places=2)
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
     def test_add_energy_kpis(self, _mock_handler):
-        """Test _add_energy_kpis method adds correct energy KPI structure."""
+        """Test _add_energy_kpis adds correct energy KPI structure."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
         exporter = EsdlKpiExporter()
-
-        # Create KPIs container
         kpis = esdl.KPIs()
         kpis.id = "test-kpis"
 
-        # Add energy KPIs
         exporter._add_energy_kpis(kpis, self.mock_kpi_results["energy"])
 
-        # Verify KPIs were added
         energy_kpis = [kpi for kpi in kpis.kpi if "energy" in kpi.name.lower()]
         self.assertGreater(len(energy_kpis), 0, "Should add energy KPIs")
-
-        # Verify energy breakdown KPI
         energy_breakdown_kpi = next(
             (kpi for kpi in energy_kpis if "Energy breakdown" in kpi.name), None
         )
         self.assertIsNotNone(energy_breakdown_kpi, "Should contain energy breakdown KPI")
-
-        # Verify unit is WATTHOUR
         self.assertEqual(energy_breakdown_kpi.quantityAndUnit.unit, esdl.UnitEnum.WATTHOUR)
-
-        # Check efficiency KPI
         efficiency_kpis = [kpi for kpi in kpis.kpi if "efficiency" in kpi.name.lower()]
         self.assertGreater(len(efficiency_kpis), 0, "Should add efficiency KPI")
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
     def test_add_emission_kpis(self, _mock_handler):
-        """Test _add_emission_kpis method adds correct emission KPI structure."""
+        """Test _add_emission_kpis adds correct emission KPI structure."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
         exporter = EsdlKpiExporter()
-
-        # Create KPIs container
         kpis = esdl.KPIs()
         kpis.id = "test-kpis"
 
-        # Add emission KPIs
         exporter._add_emission_kpis(kpis, self.mock_kpi_results["emissions"])
 
-        # Verify KPIs were added
         emission_kpis = [
             kpi for kpi in kpis.kpi if "emission" in kpi.name.lower() or "co2" in kpi.name.lower()
         ]
         self.assertGreater(len(emission_kpis), 0, "Should add emission KPIs")
 
-        # Verify emission KPI structure
         emission_kpi = emission_kpis[0]
         self.assertEqual(
             emission_kpi.quantityAndUnit.physicalQuantity, esdl.PhysicalQuantityEnum.EMISSION
@@ -206,215 +155,92 @@ class TestEsdlKpiExporter(unittest.TestCase):
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
     def test_export_file_mode(self, mock_handler):
-        """Test export method in file mode."""
+        """Test export method in file mode saves to disk and returns True."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
-        # Mock handler behavior
         mock_esdl_system = self.create_mock_esdl_system()
         mock_handler_instance = mock_handler.return_value
-        mock_handler_instance.load_file.return_value = mock_esdl_system
-
-        exporter = EsdlKpiExporter()
         output_file = f"{self.test_temp_dir}/test_output.esdl"
 
-        # Test export to file
+        exporter = EsdlKpiExporter()
         result = exporter.export(
-            self.mock_kpi_results, self.mock_energy_system, output_file, level="system"
+            self.mock_kpi_results, mock_esdl_system, output_file, level="system"
         )
 
-        # Verify file mode returns True
         self.assertTrue(result)
-
-        # Verify handler methods were called
-        mock_handler_instance.load_file.assert_called_once_with("test_input.esdl")
         mock_handler_instance.save.assert_called_once_with(output_file)
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
     def test_export_data_structure_mode(self, mock_handler):
-        """Test export method in data structure mode."""
+        """Test export method in data structure mode returns esdl.EnergySystem without saving."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
-        # Mock handler behavior
         mock_esdl_system = self.create_mock_esdl_system()
-        mock_handler_instance = mock_handler.return_value
-        mock_handler_instance.load_file.return_value = mock_esdl_system
+        exporter = EsdlKpiExporter()
+
+        result = exporter.export(
+            self.mock_kpi_results, mock_esdl_system, destination=None, level="system"
+        )
+
+        self.assertIsInstance(result, esdl.EnergySystem)
+        self.assertEqual(result.id, "test-system")
+        main_area = result.instance[0].area
+        self.assertIsNotNone(main_area.KPIs)
+        self.assertGreater(len(main_area.KPIs.kpi), 0)
+        mock_handler.return_value.save.assert_not_called()
+
+    def test_export_none_esdl_system_raises_error(self):
+        """Test that passing None as esdl_energy_system raises ValueError."""
+        from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
         exporter = EsdlKpiExporter()
 
-        # Test export without destination (data structure mode)
-        result = exporter.export(
-            self.mock_kpi_results, self.mock_energy_system, destination=None, level="system"
-        )
+        with self.assertRaises(ValueError, msg="None esdl_energy_system should raise ValueError"):
+            exporter.export(self.mock_kpi_results, None, destination=None, level="system")  # type: ignore[arg-type]
 
-        # Verify data structure mode returns ESDL object
-        self.assertIsInstance(result, esdl.EnergySystem)
-
-        # Verify handler load was called but save was not
-        mock_handler_instance.load_file.assert_called_once_with("test_input.esdl")
-        mock_handler_instance.save.assert_not_called()
-
-    @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
-    def test_invalid_level_raises_error(self, mock_handler):
+    def test_export_invalid_level_raises_error(self):
         """Test that invalid level parameter raises ValueError."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
-        mock_esdl_system = self.create_mock_esdl_system()
-        mock_handler_instance = mock_handler.return_value
-        mock_handler_instance.load_file.return_value = mock_esdl_system
-
         exporter = EsdlKpiExporter()
 
-        # Test invalid level
-        with self.assertRaises(ValueError, msg="Should raise ValueError for invalid level"):
+        with self.assertRaises(ValueError):
             exporter.export(
                 self.mock_kpi_results,
-                self.mock_energy_system,
+                self.create_mock_esdl_system(),
                 destination=None,
                 level="invalid_level",
             )
 
-    @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
-    def test_missing_source_metadata_raises_error(self, _mock_handler):
-        """Test that missing source metadata raises ValueError."""
+    def test_export_empty_kpi_data(self):
+        """Test that export handles empty KPI data gracefully."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
         exporter = EsdlKpiExporter()
-
-        # Energy system without source metadata and no stored ESDL object
-        mock_energy_system_no_metadata = Mock()
-        mock_energy_system_no_metadata.source_metadata = {}
-        mock_energy_system_no_metadata.esdl_energy_system = None
-
-        # Test missing ESDL file
-        with self.assertRaises(ValueError, msg="Should raise ValueError when ESDL file is missing"):
-            exporter.export(
-                self.mock_kpi_results,
-                mock_energy_system_no_metadata,
-                destination=None,
-                level="system",
-            )
-
-    @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
-    def test_empty_kpi_data_handling(self, mock_handler):
-        """Test handling of empty KPI data."""
-        from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
-
-        mock_esdl_system = self.create_mock_esdl_system()
-        mock_handler_instance = mock_handler.return_value
-        mock_handler_instance.load_file.return_value = mock_esdl_system
-
-        exporter = EsdlKpiExporter()
-
-        # Test with empty results
-        empty_results = {"financials": {}, "energy": {}, "emissions": {}}
-
         result = exporter.export(
-            empty_results, self.mock_energy_system, destination=None, level="system"
-        )
-
-        # Should handle gracefully and return ESDL system
-        self.assertIsInstance(result, esdl.EnergySystem)
-
-        # KPIs container should still be created
-        main_area = result.instance[0].area
-        self.assertIsNotNone(main_area.KPIs)
-
-    def test_export_from_string_loaded_esdl(self):
-        """Test export works for ESDL loaded from string (not file)."""
-        from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
-
-        # Create a mock ESDL system
-        mock_esdl_system = self.create_mock_esdl_system()
-
-        # Create energy system with stored ESDL object (as set by EsdlAdapter)
-        mock_energy_system = Mock()
-        mock_energy_system.source_metadata = {"esdl_source": "string"}
-        mock_energy_system.esdl_energy_system = mock_esdl_system
-
-        exporter = EsdlKpiExporter()
-
-        # Export should work without file path - uses stored ESDL object
-        result = exporter.export(
-            self.mock_kpi_results,
-            mock_energy_system,
+            {"financials": {}, "energy": {}, "emissions": {}},
+            self.create_mock_esdl_system(),
             destination=None,
             level="system",
         )
 
-        # Verify export succeeded
-        self.assertIsInstance(result, esdl.EnergySystem)
-        self.assertEqual(result.id, "test-system")
-
-        # Verify KPIs were added
-        main_area = result.instance[0].area
-        self.assertIsNotNone(main_area.KPIs)
-        self.assertGreater(len(main_area.KPIs.kpi), 0)
-
-    def test_export_from_string_without_object_raises_error(self):
-        """Test export fails gracefully when string-loaded but no ESDL object stored."""
-        from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
-
-        # Create energy system with string source but no stored ESDL object
-        mock_energy_system = Mock()
-        mock_energy_system.source_metadata = {"esdl_source": "string"}
-        mock_energy_system.esdl_energy_system = None
-
-        exporter = EsdlKpiExporter()
-
-        # Should raise ValueError when no ESDL object and no file path available
-        with self.assertRaises(ValueError):
-            exporter.export(
-                self.mock_kpi_results,
-                mock_energy_system,
-                destination=None,
-                level="system",
-            )
-
-    @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
-    def test_export_uses_stored_esdl_object_over_file(self, mock_handler):
-        """Test that export uses stored ESDL object and skips file loading."""
-        from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
-
-        mock_esdl_system = self.create_mock_esdl_system()
-
-        # Energy system with both a file path AND a stored ESDL object
-        mock_energy_system = Mock()
-        mock_energy_system.source_metadata = {"esdl_file": "test_input.esdl"}
-        mock_energy_system.esdl_energy_system = mock_esdl_system
-
-        exporter = EsdlKpiExporter()
-
-        result = exporter.export(
-            self.mock_kpi_results,
-            mock_energy_system,
-            destination=None,
-            level="system",
+        self.assertIsInstance(
+            result, esdl.EnergySystem, "Should handle gracefully and return ESDL system"
         )
-
-        # Stored object should be used — handler.load_file must NOT be called
-        mock_handler.return_value.load_file.assert_not_called()
-
-        # Verify export succeeded with the stored object
-        self.assertIsInstance(result, esdl.EnergySystem)
-        self.assertEqual(result.id, "test-system")
+        main_area = result.instance[0].area
+        self.assertIsNotNone(main_area.KPIs, "KPIs container should still be created")
 
     def test_repeated_export_does_not_accumulate_kpis(self):
         """Test that exporting twice does not duplicate KPIs."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
         mock_esdl_system = self.create_mock_esdl_system()
-
-        mock_energy_system = Mock()
-        mock_energy_system.source_metadata = {"esdl_source": "string"}
-        mock_energy_system.esdl_energy_system = mock_esdl_system
-
         exporter = EsdlKpiExporter()
 
-        # Export twice
-        exporter.export(self.mock_kpi_results, mock_energy_system, destination=None, level="system")
+        exporter.export(self.mock_kpi_results, mock_esdl_system, destination=None, level="system")
         kpi_count_1 = len(mock_esdl_system.instance[0].area.KPIs.kpi)
 
-        exporter.export(self.mock_kpi_results, mock_energy_system, destination=None, level="system")
+        exporter.export(self.mock_kpi_results, mock_esdl_system, destination=None, level="system")
         kpi_count_2 = len(mock_esdl_system.instance[0].area.KPIs.kpi)
 
         self.assertEqual(kpi_count_1, kpi_count_2, "Repeated export should not accumulate KPIs")

--- a/unit_test/test_esdl_kpi_exporter.py
+++ b/unit_test/test_esdl_kpi_exporter.py
@@ -15,7 +15,7 @@ class TestEsdlKpiExporter(unittest.TestCase):
         """Set up test environment with mock data."""
         # Mock KPI results structure
         self.mock_kpi_results = {
-            "costs": {
+            "financials": {
                 "capex": {"All": 100000.0, "Producer": 60000.0, "Consumer": 40000.0},
                 "opex": {"All": 20000.0, "Producer": 15000.0, "Consumer": 5000.0},
                 "npv": 250000.0,
@@ -106,8 +106,8 @@ class TestEsdlKpiExporter(unittest.TestCase):
             self.assertEqual(item.value, expected_value)
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
-    def test_add_cost_kpis(self, _mock_handler):
-        """Test _add_cost_kpis method adds correct cost KPI structure."""
+    def test_add_financial_kpis(self, _mock_handler):
+        """Test _add_financial_kpis method adds correct cost KPI structure."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
         exporter = EsdlKpiExporter()
@@ -117,7 +117,7 @@ class TestEsdlKpiExporter(unittest.TestCase):
         kpis.id = "test-kpis"
 
         # Add cost KPIs
-        exporter._add_cost_kpis(kpis, self.mock_kpi_results["costs"])
+        exporter._add_financial_kpis(kpis, self.mock_kpi_results["financials"])
 
         # Verify KPIs were added
         self.assertGreater(len(kpis.kpi), 0, "Should add cost KPIs")
@@ -140,8 +140,8 @@ class TestEsdlKpiExporter(unittest.TestCase):
         self.assertIsNotNone(opex_item, "Should contain OPEX item")
 
         # Verify values (use pre-calculated values from cost calculator)
-        expected_capex = self.mock_kpi_results["costs"]["capex"]["All"]
-        expected_opex = self.mock_kpi_results["costs"]["opex"]["All"]
+        expected_capex = self.mock_kpi_results["financials"]["capex"]["All"]
+        expected_opex = self.mock_kpi_results["financials"]["opex"]["All"]
 
         self.assertAlmostEqual(float(capex_item.value), expected_capex, places=2)
         self.assertAlmostEqual(float(opex_item.value), expected_opex, places=2)
@@ -306,7 +306,7 @@ class TestEsdlKpiExporter(unittest.TestCase):
         exporter = EsdlKpiExporter()
 
         # Test with empty results
-        empty_results = {"costs": {}, "energy": {}, "emissions": {}}
+        empty_results = {"financials": {}, "energy": {}, "emissions": {}}
 
         result = exporter.export(
             empty_results, self.mock_energy_system, destination=None, level="system"

--- a/unit_test/test_esdl_kpi_exporter.py
+++ b/unit_test/test_esdl_kpi_exporter.py
@@ -7,6 +7,39 @@ from unittest.mock import patch
 
 from esdl import esdl
 
+# Test data constants
+_TEST_KPI_NAME_COST_BREAKDOWN = "High level cost breakdown"
+_TEST_KPI_NAME_ENERGY_BREAKDOWN = "Energy breakdown"
+_TEST_KPI_NAME_EFFICIENCY = "efficiency"
+_TEST_KPI_NAME_NPV = "Net Present Value [EUR]"
+_TEST_KPI_NAME_LCOE = "Levelized Cost of Energy [EUR/MWh]"
+_TEST_KPI_NAME_EAC = "Equivalent Annual Cost [EUR/yr]"
+_TEST_KPI_NAME_TCO = "Total Cost of Ownership [EUR]"
+_TEST_KPI_NAME_CO2_EMISSIONS = "CO2 emissions [g]"
+_TEST_KPI_NAME_CO2_PER_MWH = "CO2 emissions per MWh [g/MWh]"
+_TEST_KPI_NAME_ENERGY_EFFICIENCY = "Energy efficiency [-]"
+_TEST_KPI_NAME_ENERGY_BREAKDOWN_WH = "Energy breakdown [Wh]"
+
+
+def _create_mock_esdl_system() -> esdl.EnergySystem:
+    """Create a minimal mock ESDL energy system for testing."""
+    energy_system = esdl.EnergySystem()
+    energy_system.id = "test-system"
+    energy_system.name = "Test System"
+
+    instance = esdl.Instance()
+    instance.id = "test-instance"
+    instance.name = "Test Instance"
+
+    area = esdl.Area()
+    area.id = "test-area"
+    area.name = "Test Area"
+
+    instance.area = area
+    energy_system.instance.append(instance)
+
+    return energy_system
+
 
 class TestEsdlKpiExporter(unittest.TestCase):
     """Test EsdlKpiExporter class functionality in isolation."""
@@ -29,43 +62,34 @@ class TestEsdlKpiExporter(unittest.TestCase):
             "emissions": {"total": 1200.0, "per_mwh": 2.4},
         }
 
-        self.test_temp_dir = tempfile.mkdtemp(prefix="esdl_exporter_test_")
-
-    def tearDown(self) -> None:
-        """Clean up temporary files."""
-        import shutil
-
-        if Path(self.test_temp_dir).exists():
-            shutil.rmtree(self.test_temp_dir)
-
     def create_mock_esdl_system(self) -> esdl.EnergySystem:
         """Create a minimal mock ESDL energy system for testing."""
-        energy_system = esdl.EnergySystem()
-        energy_system.id = "test-system"
-        energy_system.name = "Test System"
+        return _create_mock_esdl_system()
 
-        instance = esdl.Instance()
-        instance.id = "test-instance"
-        instance.name = "Test Instance"
+    def _find_distribution_item(self, kpi, label_fragment):
+        """Find a distribution item by label substring."""
+        return next(
+            (item for item in kpi.distribution.stringItem if label_fragment in item.label),
+            None,
+        )
 
-        area = esdl.Area()
-        area.id = "test-area"
-        area.name = "Test Area"
-
-        instance.area = area
-        energy_system.instance.append(instance)
-
-        return energy_system
+    def _get_kpi_count(self, system):
+        """Get the number of KPIs in the system."""
+        return len(system.instance[0].area.KPIs.kpi)
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
     def test_create_distribution_kpi(self, _mock_handler):
         """Test _create_distribution_kpi method creates correct ESDL structure."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
+        # Arrange
         exporter = EsdlKpiExporter()
         items = [("CAPEX", 5000.0), ("OPEX", 3000.0)]
+
+        # Act
         kpi = exporter._create_distribution_kpi("Test KPI [EUR]", "COST", "EURO", items)
 
+        # Assert
         self.assertIsInstance(kpi, esdl.DistributionKPI)
         self.assertEqual(kpi.name, "Test KPI [EUR]")
         self.assertIsNotNone(kpi.id)
@@ -85,23 +109,22 @@ class TestEsdlKpiExporter(unittest.TestCase):
         """Test _add_financial_kpis adds correct cost KPI structure."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
+        # Arrange
         exporter = EsdlKpiExporter()
         kpis = esdl.KPIs()
         kpis.id = "test-kpis"
 
+        # Act
         exporter._add_financial_kpis(kpis, self.mock_kpi_results["financials"])
 
+        # Assert
         self.assertGreater(len(kpis.kpi), 0)
-        high_level_kpis = [kpi for kpi in kpis.kpi if "High level cost breakdown" in kpi.name]
+        high_level_kpis = [kpi for kpi in kpis.kpi if _TEST_KPI_NAME_COST_BREAKDOWN in kpi.name]
         self.assertGreater(len(high_level_kpis), 0)
 
         cost_kpi = high_level_kpis[0]
-        capex_item = next(
-            (item for item in cost_kpi.distribution.stringItem if "CAPEX" in item.label), None
-        )
-        opex_item = next(
-            (item for item in cost_kpi.distribution.stringItem if "OPEX" in item.label), None
-        )
+        capex_item = self._find_distribution_item(cost_kpi, "CAPEX")
+        opex_item = self._find_distribution_item(cost_kpi, "OPEX")
         self.assertIsNotNone(capex_item, "Should contain CAPEX item")
         self.assertIsNotNone(opex_item, "Should contain OPEX item")
 
@@ -115,20 +138,23 @@ class TestEsdlKpiExporter(unittest.TestCase):
         """Test _add_energy_kpis adds correct energy KPI structure."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
+        # Arrange
         exporter = EsdlKpiExporter()
         kpis = esdl.KPIs()
         kpis.id = "test-kpis"
 
+        # Act
         exporter._add_energy_kpis(kpis, self.mock_kpi_results["energy"])
 
+        # Assert
         energy_kpis = [kpi for kpi in kpis.kpi if "energy" in kpi.name.lower()]
         self.assertGreater(len(energy_kpis), 0, "Should add energy KPIs")
         energy_breakdown_kpi = next(
-            (kpi for kpi in energy_kpis if "Energy breakdown" in kpi.name), None
+            (kpi for kpi in energy_kpis if _TEST_KPI_NAME_ENERGY_BREAKDOWN in kpi.name), None
         )
         self.assertIsNotNone(energy_breakdown_kpi, "Should contain energy breakdown KPI")
         self.assertEqual(energy_breakdown_kpi.quantityAndUnit.unit, esdl.UnitEnum.WATTHOUR)
-        efficiency_kpis = [kpi for kpi in kpis.kpi if "efficiency" in kpi.name.lower()]
+        efficiency_kpis = [kpi for kpi in kpis.kpi if _TEST_KPI_NAME_EFFICIENCY in kpi.name.lower()]
         self.assertGreater(len(efficiency_kpis), 0, "Should add efficiency KPI")
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
@@ -136,12 +162,15 @@ class TestEsdlKpiExporter(unittest.TestCase):
         """Test _add_emission_kpis adds correct emission KPI structure."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
+        # Arrange
         exporter = EsdlKpiExporter()
         kpis = esdl.KPIs()
         kpis.id = "test-kpis"
 
+        # Act
         exporter._add_emission_kpis(kpis, self.mock_kpi_results["emissions"])
 
+        # Assert
         emission_kpis = [
             kpi for kpi in kpis.kpi if "emission" in kpi.name.lower() or "co2" in kpi.name.lower()
         ]
@@ -157,30 +186,36 @@ class TestEsdlKpiExporter(unittest.TestCase):
         """Test export method in file mode saves to disk and returns True."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
-        mock_esdl_system = self.create_mock_esdl_system()
-        output_file = f"{self.test_temp_dir}/test_output.esdl"
+        with tempfile.TemporaryDirectory(prefix="esdl_exporter_test_") as test_temp_dir:
+            # Arrange
+            mock_esdl_system = self.create_mock_esdl_system()
+            output_file = f"{test_temp_dir}/test_output.esdl"
+            exporter = EsdlKpiExporter()
 
-        exporter = EsdlKpiExporter()
-        result = exporter.export(
-            self.mock_kpi_results, mock_esdl_system, output_file, level="system"
-        )
+            # Act
+            result = exporter.export(
+                self.mock_kpi_results, mock_esdl_system, output_file, level="system"
+            )
 
-        self.assertTrue(result)
-        # Check that the file was actually created
-        self.assertTrue(Path(output_file).exists(), f"Output file {output_file} was not created.")
+            # Assert
+            self.assertTrue(result)
+            self.assertTrue(Path(output_file).exists(), f"Output file {output_file} was not created.")
 
     @patch("kpicalculator.reporting.esdl_kpi_exporter.EnergySystemHandler")
     def test_export_data_structure_mode(self, mock_handler):
         """Test export method in data structure mode returns esdl.EnergySystem without saving."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
+        # Arrange
         mock_esdl_system = self.create_mock_esdl_system()
         exporter = EsdlKpiExporter()
 
+        # Act
         result = exporter.export(
             self.mock_kpi_results, mock_esdl_system, destination=None, level="system"
         )
 
+        # Assert
         self.assertIsInstance(result, esdl.EnergySystem)
         self.assertEqual(result.id, "test-system")
         main_area = result.instance[0].area
@@ -192,17 +227,21 @@ class TestEsdlKpiExporter(unittest.TestCase):
         """Test that passing None as esdl_energy_system raises ValueError."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
+        # Arrange
         exporter = EsdlKpiExporter()
 
-        with self.assertRaises(ValueError, msg="None esdl_energy_system should raise ValueError"):
+        # Act & Assert
+        with self.assertRaises(ValueError):
             exporter.export(self.mock_kpi_results, None, destination=None, level="system")  # type: ignore[arg-type]
 
     def test_export_invalid_level_raises_error(self):
         """Test that invalid level parameter raises ValueError."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
+        # Arrange
         exporter = EsdlKpiExporter()
 
+        # Act & Assert
         with self.assertRaises(ValueError):
             exporter.export(
                 self.mock_kpi_results,
@@ -215,14 +254,20 @@ class TestEsdlKpiExporter(unittest.TestCase):
         """Test that export handles empty KPI data gracefully."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
+        # Arrange
         exporter = EsdlKpiExporter()
+        empty_kpi_results = {"financials": {}, "energy": {}, "emissions": {}}
+        mock_esdl_system = self.create_mock_esdl_system()
+
+        # Act
         result = exporter.export(
-            {"financials": {}, "energy": {}, "emissions": {}},
-            self.create_mock_esdl_system(),
+            empty_kpi_results,
+            mock_esdl_system,
             destination=None,
             level="system",
         )
 
+        # Assert
         self.assertIsInstance(
             result, esdl.EnergySystem, "Should handle gracefully and return ESDL system"
         )
@@ -233,102 +278,149 @@ class TestEsdlKpiExporter(unittest.TestCase):
         """Test that exporting twice does not duplicate KPIs."""
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
+        # Arrange
         mock_esdl_system = self.create_mock_esdl_system()
         exporter = EsdlKpiExporter()
 
+        # Act
         exporter.export(self.mock_kpi_results, mock_esdl_system, destination=None, level="system")
-        kpi_count_1 = len(mock_esdl_system.instance[0].area.KPIs.kpi)
+        kpi_count_1 = self._get_kpi_count(mock_esdl_system)
 
         exporter.export(self.mock_kpi_results, mock_esdl_system, destination=None, level="system")
-        kpi_count_2 = len(mock_esdl_system.instance[0].area.KPIs.kpi)
+        kpi_count_2 = self._get_kpi_count(mock_esdl_system)
 
+        # Assert
         self.assertEqual(kpi_count_1, kpi_count_2, "Repeated export should not accumulate KPIs")
 
 
 class TestEsdlKpiExporterSkipZero(unittest.TestCase):
     """Test that KPI elements with zero (missing-data) values are omitted from ESDL output."""
 
-    def _make_system(self) -> esdl.EnergySystem:
-        energy_system = esdl.EnergySystem()
-        energy_system.id = "s"
-        instance = esdl.Instance()
-        instance.id = "i"
-        area = esdl.Area()
-        area.id = "a"
-        instance.area = area
-        energy_system.instance.append(instance)
-        return energy_system
-
     def _export(self, results: dict) -> dict:
         from kpicalculator.reporting.esdl_kpi_exporter import EsdlKpiExporter
 
-        es = self._make_system()
+        es = _create_mock_esdl_system()
         exported = EsdlKpiExporter().export(results, es, destination=None, level="system")
-        assert isinstance(exported, esdl.EnergySystem)
+        self.assertIsInstance(exported, esdl.EnergySystem)
         return {kpi.name: kpi for kpi in exported.instance[0].area.KPIs.kpi}
 
     def test__zero_npv__omits_npv_kpi(self) -> None:
+        # Arrange
         results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "npv": 0.0}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertNotIn("Net Present Value [EUR]", kpi_by_name)
+
+        # Assert
+        self.assertNotIn(_TEST_KPI_NAME_NPV, kpi_by_name)
 
     def test__nonzero_npv__includes_npv_kpi(self) -> None:
+        # Arrange
         results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "npv": 5000.0}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertIn("Net Present Value [EUR]", kpi_by_name)
+
+        # Assert
+        self.assertIn(_TEST_KPI_NAME_NPV, kpi_by_name)
 
     def test__zero_lcoe__omits_lcoe_kpi(self) -> None:
+        # Arrange
         results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "lcoe": 0.0}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertNotIn("Levelized Cost of Energy [EUR/MWh]", kpi_by_name)
+
+        # Assert
+        self.assertNotIn(_TEST_KPI_NAME_LCOE, kpi_by_name)
 
     def test__nonzero_lcoe__includes_lcoe_kpi(self) -> None:
+        # Arrange
         results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "lcoe": 0.05}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertIn("Levelized Cost of Energy [EUR/MWh]", kpi_by_name)
+
+        # Assert
+        self.assertIn(_TEST_KPI_NAME_LCOE, kpi_by_name)
 
     def test__zero_eac__omits_eac_kpi(self) -> None:
+        # Arrange
         results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "eac": 0.0}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertNotIn("Equivalent Annual Cost [EUR/yr]", kpi_by_name)
+
+        # Assert
+        self.assertNotIn(_TEST_KPI_NAME_EAC, kpi_by_name)
 
     def test__zero_tco__omits_tco_kpi(self) -> None:
+        # Arrange
         results = {"financials": {"capex": {"All": 0.0}, "opex": {"All": 0.0}, "tco": 0.0}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertNotIn("Total Cost of Ownership [EUR]", kpi_by_name)
+
+        # Assert
+        self.assertNotIn(_TEST_KPI_NAME_TCO, kpi_by_name)
 
     def test__zero_energy_values__omits_energy_breakdown_kpi(self) -> None:
+        # Arrange
         results = {"energy": {"consumption": 0.0, "production": 0.0, "demand": 0.0}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertNotIn("Energy breakdown [Wh]", kpi_by_name)
+
+        # Assert
+        self.assertNotIn(_TEST_KPI_NAME_ENERGY_BREAKDOWN_WH, kpi_by_name)
 
     def test__nonzero_production_only__includes_energy_breakdown(self) -> None:
+        # Arrange
         results = {"energy": {"consumption": 0.0, "production": 1e9, "demand": 0.0}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertIn("Energy breakdown [Wh]", kpi_by_name)
+
+        # Assert
+        self.assertIn(_TEST_KPI_NAME_ENERGY_BREAKDOWN_WH, kpi_by_name)
         items = {
             item.label: item.value
-            for item in kpi_by_name["Energy breakdown [Wh]"].distribution.stringItem
+            for item in kpi_by_name[_TEST_KPI_NAME_ENERGY_BREAKDOWN_WH].distribution.stringItem
         }
         self.assertNotIn("Consumption", items)
         self.assertIn("Production", items)
 
     def test__zero_efficiency__omits_efficiency_kpi(self) -> None:
+        # Arrange
         results = {"energy": {"efficiency": 0.0}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertNotIn("Energy efficiency [-]", kpi_by_name)
+
+        # Assert
+        self.assertNotIn(_TEST_KPI_NAME_ENERGY_EFFICIENCY, kpi_by_name)
 
     def test__zero_emissions__omits_co2_kpis(self) -> None:
+        # Arrange
         results = {"emissions": {"total": 0.0, "per_mwh": 0.0}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertNotIn("CO2 emissions [g]", kpi_by_name)
-        self.assertNotIn("CO2 emissions per MWh [g/MWh]", kpi_by_name)
+
+        # Assert
+        self.assertNotIn(_TEST_KPI_NAME_CO2_EMISSIONS, kpi_by_name)
+        self.assertNotIn(_TEST_KPI_NAME_CO2_PER_MWH, kpi_by_name)
 
     def test__nonzero_emissions__includes_co2_kpis(self) -> None:
+        # Arrange
         results = {"emissions": {"total": 500.0, "per_mwh": 1.2}}
+
+        # Act
         kpi_by_name = self._export(results)
-        self.assertIn("CO2 emissions [g]", kpi_by_name)
-        self.assertIn("CO2 emissions per MWh [g/MWh]", kpi_by_name)
+
+        # Assert
+        self.assertIn(_TEST_KPI_NAME_CO2_EMISSIONS, kpi_by_name)
+        self.assertIn(_TEST_KPI_NAME_CO2_PER_MWH, kpi_by_name)
 
 
 if __name__ == "__main__":

--- a/unit_test/test_examples.py
+++ b/unit_test/test_examples.py
@@ -160,11 +160,13 @@ class TestReadmeExamples:
         assert main_area.KPIs is not None
         kpi_by_name = {kpi.name: kpi for kpi in main_area.KPIs.kpi}
 
-        # All three KPI categories must be present
+        # Financial KPIs come from ESDL costInformation and must always be present
         assert "High level cost breakdown [EUR]" in kpi_by_name
         assert "Net Present Value [EUR]" in kpi_by_name
-        assert "Energy breakdown [Wh]" in kpi_by_name
-        assert "CO2 emissions [g]" in kpi_by_name
+        # Energy and emission KPIs are omitted when no time series data is loaded
+        # (exporter skips zero-fallback values — see DESIGN.md §12.2)
+        assert "Energy breakdown [Wh]" not in kpi_by_name
+        assert "CO2 emissions [g]" not in kpi_by_name
 
         # Cost values come from ESDL costInformation, not time series — must be non-zero
         expected_capex = results["financials"]["capex"]["All"]
@@ -224,8 +226,9 @@ class TestReadmeExamples:
         assert "KPIs" in area, "KPIs element missing from output ESDL"
         kpi_by_name = {kpi["@name"]: kpi for kpi in area["KPIs"]["kpi"]}
         assert "High level cost breakdown [EUR]" in kpi_by_name
-        assert "Energy breakdown [Wh]" in kpi_by_name
-        assert "CO2 emissions [g]" in kpi_by_name
+        # No time series loaded — energy and emission KPIs are omitted (skip-zero policy)
+        assert "Energy breakdown [Wh]" not in kpi_by_name
+        assert "CO2 emissions [g]" not in kpi_by_name
 
         # KPI values round-trip the calculated results exactly
         expected_capex = results["financials"]["capex"]["All"]

--- a/unit_test/test_examples.py
+++ b/unit_test/test_examples.py
@@ -28,9 +28,9 @@ class TestReadmeExamples:
 
         results = calculate_kpis(esdl_file=esdl_file, time_series=time_series)
 
-        assert "costs" in results
-        assert "capex" in results["costs"]
-        assert "All" in results["costs"]["capex"]
+        assert "financials" in results
+        assert "capex" in results["financials"]
+        assert "All" in results["financials"]["capex"]
 
     def test_basic_usage_production(self) -> None:
         """Test Basic Usage - production example.
@@ -43,7 +43,7 @@ class TestReadmeExamples:
 
         results = calculate_kpis(esdl_file=esdl_file, time_series=time_series)
 
-        assert "costs" in results
+        assert "financials" in results
 
     def test_basic_usage_with_parameters(self) -> None:
         """Test Basic Usage - with optional parameters.
@@ -56,7 +56,7 @@ class TestReadmeExamples:
 
         results = calculate_kpis(esdl_file=esdl_file, system_lifetime=30, time_series=time_series)
 
-        assert "costs" in results
+        assert "financials" in results
 
     def test_basic_usage_testing_override(self) -> None:
         """Test Basic Usage - testing with XML override."""
@@ -65,7 +65,7 @@ class TestReadmeExamples:
 
         results = calculate_kpis(esdl_file=esdl_file, time_series=time_series)
 
-        assert "costs" in results
+        assert "financials" in results
 
     def test_timeseries_dataframes_produce_valid_kpi_results(self) -> None:
         """Test that the timeseries_dataframes parameter works with composite keys.
@@ -95,7 +95,7 @@ class TestReadmeExamples:
 
         results = calculate_kpis(esdl_file=esdl_file, timeseries_dataframes=timeseries_dataframes)
 
-        assert "costs" in results
+        assert "financials" in results
         assert "energy" in results
         assert "emissions" in results
         assert results["energy"]["consumption"] > 0, (
@@ -115,7 +115,7 @@ class TestReadmeExamples:
                 scenario["file"], time_series_file="unit_test/data/power_timeseries.xml"
             )
             results = manager.calculate_all_kpis(system_lifetime=scenario["lifetime"])
-            assert "costs" in results
+            assert "financials" in results
 
     def test_string_loaded_esdl_export(self) -> None:
         """Test full workflow: load ESDL from string, calculate KPIs, export.
@@ -140,7 +140,7 @@ class TestReadmeExamples:
         # Calculate KPIs
         results = manager.calculate_all_kpis()
 
-        assert "costs" in results
+        assert "financials" in results
         assert "energy" in results
 
         # Export to ESDL (data structure mode)
@@ -167,9 +167,9 @@ class TestReadmeExamples:
         assert "CO2 emissions [g]" in kpi_by_name
 
         # Cost values come from ESDL costInformation, not time series — must be non-zero
-        expected_capex = results["costs"]["capex"]["All"]
-        expected_opex = results["costs"]["opex"]["All"]
-        expected_npv = results["costs"]["npv"]
+        expected_capex = results["financials"]["capex"]["All"]
+        expected_opex = results["financials"]["opex"]["All"]
+        expected_npv = results["financials"]["npv"]
         assert expected_capex > 0, "Fixture ESDL has cost data; CAPEX should be non-zero"
         assert expected_opex > 0, "Fixture ESDL has cost data; OPEX should be non-zero"
         assert expected_npv > 0, "Fixture ESDL has cost data; NPV should be non-zero"
@@ -233,9 +233,9 @@ class TestReadmeExamples:
         assert "CO2 emissions [g]" in kpi_by_name
 
         # KPI values round-trip the calculated results exactly
-        expected_capex = results["costs"]["capex"]["All"]
-        expected_opex = results["costs"]["opex"]["All"]
-        expected_npv = results["costs"]["npv"]
+        expected_capex = results["financials"]["capex"]["All"]
+        expected_opex = results["financials"]["opex"]["All"]
+        expected_npv = results["financials"]["npv"]
         assert expected_capex > 0, "Fixture ESDL has cost data; CAPEX should be non-zero"
         assert expected_opex > 0, "Fixture ESDL has cost data; OPEX should be non-zero"
         assert expected_npv > 0, "Fixture ESDL has cost data; NPV should be non-zero"

--- a/unit_test/test_examples.py
+++ b/unit_test/test_examples.py
@@ -147,8 +147,8 @@ class TestReadmeExamples:
         exporter = EsdlKpiExporter()
         esdl_with_kpis = exporter.export(
             results=results,
-            energy_system=manager.energy_system,
-            destination=None,  # Return ESDL object, don't save to file
+            esdl_energy_system=manager.energy_system.esdl_energy_system,
+            destination=None,
             level="system",
         )
 
@@ -197,9 +197,7 @@ class TestReadmeExamples:
     def test_build_esdl_string_with_kpis(self) -> None:
         """Test that build_esdl_string_with_kpis embeds KPIs into an ESDL XML string.
 
-        Verifies that:
-        - The returned value is a non-empty string containing KPI XML elements.
-        - manager.energy_system.esdl_energy_system is unchanged after the call.
+        The method operates on a local EnergySystemHandler and does not modify manager state.
         """
         from pathlib import Path
 
@@ -213,17 +211,14 @@ class TestReadmeExamples:
         results = manager.calculate_all_kpis()
 
         original_esdl_object = manager.energy_system.esdl_energy_system
-
         output_string = manager.build_esdl_string_with_kpis(esdl_string, results)
 
-        # State is restored after the call
-        assert manager.energy_system.esdl_energy_system is original_esdl_object
-
-        # Output is a non-empty string
+        assert manager.energy_system.esdl_energy_system is original_esdl_object, (
+            "build_esdl_string_with_kpis must not modify manager.energy_system"
+        )
         assert isinstance(output_string, str)
         assert len(output_string) > 0
 
-        # KPI elements are present in the output XML
         parsed = xmltodict.parse(output_string)
         area = parsed["esdl:EnergySystem"]["instance"]["area"]
         assert "KPIs" in area, "KPIs element missing from output ESDL"

--- a/unit_test/test_kpi_calculator.py
+++ b/unit_test/test_kpi_calculator.py
@@ -1384,5 +1384,448 @@ class BaseAdapterValidationTest(unittest.TestCase):
         self.assertEqual(len(result.errors), 2)
 
 
+class EacTcoCalculatorTest(unittest.TestCase):
+    """Unit tests for EAC and TCO calculations in CostCalculator.
+
+    Uses a minimal synthetic EnergySystem — no file I/O, no ESDL parsing — so
+    tests are fast and isolated.  Each test pins a specific mathematical property
+    of the formulas.
+    """
+
+    def _make_system(
+        self,
+        investment: float = 100_000.0,
+        opex_annual: float = 5_000.0,
+        technical_lifetime: float = 40.0,
+    ) -> "EnergySystem":  # noqa: F821
+        from kpicalculator.adapters.common_model import Asset, AssetType, EnergySystem
+
+        asset = Asset(
+            id="test_asset",
+            name="Test Asset",
+            asset_type=AssetType.PRODUCER,
+            investment_cost=investment,
+            investment_cost_unit="EUR",
+            fixed_operational_cost=opex_annual,
+            fixed_operational_cost_unit="EUR/yr",
+            technical_lifetime=technical_lifetime,
+        )
+        return EnergySystem(name="Test System", assets=[asset])
+
+    # --- Annuity factor spot checks (ported from mesido test_end_scenario_sizing_annualized.py) ---
+
+    def test_annuity_factor_zero_discount_rate_n1(self) -> None:
+        """annuity_factor(r=0, TL=1) == 1.0: EAC = CAPEX / TL = CAPEX.
+
+        At r=0 the annuity degenerates to CAPEX / TL. For TL=1, annualized_CAPEX = CAPEX.
+        Ported from mesido Assertion 4.
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 1_000.0
+        system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=1.0)
+        calc = CostCalculator(system)
+        eac = calc.calculate_eac(discount_rate=0.0)
+
+        self.assertAlmostEqual(eac, investment, places=10)
+
+    def test_annuity_factor_10pct_discount_rate_tl1(self) -> None:
+        """annuity_factor(r=0.10, TL=1) == 1.1: annualized_CAPEX = CAPEX × 1.1.
+
+        For TL=1: factor = r / (1 - (1+r)^-1) = 1+r = 1.1.
+        Ported from mesido Assertion 4.
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 1_000.0
+        system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=1.0)
+        calc = CostCalculator(system)
+        eac = calc.calculate_eac(discount_rate=10.0)
+
+        self.assertAlmostEqual(eac, investment * 1.1, places=10)
+
+    # --- EAC tests ---
+
+    def test_eac_annuity_formula_per_asset(self) -> None:
+        """EAC applies annuity formula per asset using technical_lifetime, not system_lifetime.
+
+        For a single asset: investment=100,000, r=5%, TL=40yr:
+            annuity_factor = 0.05 / (1 - 1.05^-40)
+            EAC = investment × annuity_factor
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 100_000.0
+        technical_lifetime = 40.0
+        discount_rate = 5.0
+        system = self._make_system(
+            investment=investment, opex_annual=0.0, technical_lifetime=technical_lifetime
+        )
+        calc = CostCalculator(system)
+        eac = calc.calculate_eac(discount_rate=discount_rate)
+
+        r = discount_rate / 100.0
+        expected = investment * r / (1.0 - (1.0 + r) ** -technical_lifetime)
+        self.assertAlmostEqual(eac, expected, places=10)
+
+    def test_eac_zero_discount_rate_equals_capex_divided_by_technical_lifetime(self) -> None:
+        """At r=0, EAC = CAPEX / technical_lifetime (simple straight-line depreciation)."""
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 100_000.0
+        technical_lifetime = 40.0
+        system = self._make_system(
+            investment=investment, opex_annual=0.0, technical_lifetime=technical_lifetime
+        )
+        calc = CostCalculator(system)
+        eac = calc.calculate_eac(discount_rate=0.0)
+
+        self.assertAlmostEqual(eac, investment / technical_lifetime, places=10)
+
+    def test_eac_higher_discount_rate_yields_higher_eac(self) -> None:
+        """Higher discount rate produces higher EAC (higher annuity factor)."""
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        system = self._make_system()
+        calc = CostCalculator(system)
+
+        eac_low = calc.calculate_eac(discount_rate=2.0)
+        eac_high = calc.calculate_eac(discount_rate=8.0)
+
+        self.assertGreater(eac_high, eac_low)
+
+    def test_eac_per_asset_discount_rate_overrides_fallback(self) -> None:
+        """Per-asset discount_rate takes precedence over the fallback parameter.
+
+        When asset.discount_rate is set, calculate_eac must use it instead of
+        the discount_rate argument.  This test constructs two systems that are
+        identical except for how the rate is supplied — directly on the asset vs.
+        via the fallback parameter — and asserts they produce the same EAC.
+        """
+        import math
+
+        from kpicalculator.adapters.common_model import Asset, AssetType, EnergySystem
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 100_000.0
+        technical_lifetime = 40.0
+        asset_rate = 7.0  # rate stored on the asset
+        fallback_rate = 3.0  # different fallback — must be ignored
+
+        # OPEX is explicitly zero so EAC == annualized CAPEX and the expected
+        # formula below can use investment directly without an OPEX term.
+        asset_with_rate = Asset(
+            id="asset_a",
+            name="Asset A",
+            asset_type=AssetType.PRODUCER,
+            investment_cost=investment,
+            investment_cost_unit="EUR",
+            fixed_operational_cost=0.0,
+            technical_lifetime=technical_lifetime,
+            discount_rate=asset_rate,
+        )
+        system_with_rate = EnergySystem(name="System A", assets=[asset_with_rate])
+
+        # Reference system: no per-asset rate, fallback matches asset_rate
+        asset_no_rate = Asset(
+            id="asset_b",
+            name="Asset B",
+            asset_type=AssetType.PRODUCER,
+            investment_cost=investment,
+            investment_cost_unit="EUR",
+            fixed_operational_cost=0.0,
+            technical_lifetime=technical_lifetime,
+        )
+        system_no_rate = EnergySystem(name="System B", assets=[asset_no_rate])
+
+        eac_asset_rate = CostCalculator(system_with_rate).calculate_eac(discount_rate=fallback_rate)
+        eac_fallback = CostCalculator(system_no_rate).calculate_eac(discount_rate=asset_rate)
+
+        # Both should equal the annuity at asset_rate
+        r = asset_rate / 100.0
+        expected = investment * r / (1.0 - math.pow(1.0 + r, -technical_lifetime))
+        self.assertAlmostEqual(eac_asset_rate, expected, places=10)
+        self.assertAlmostEqual(eac_asset_rate, eac_fallback, places=10)
+
+        # Confirm it differs from what the fallback_rate would give
+        eac_at_fallback_rate = CostCalculator(system_no_rate).calculate_eac(
+            discount_rate=fallback_rate
+        )
+        self.assertNotAlmostEqual(eac_asset_rate, eac_at_fallback_rate, places=2)
+
+    def test_eac_opex_passed_through_directly(self) -> None:
+        """EAC includes annual OPEX directly — OPEX is not annualized."""
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        opex_annual = 5_000.0
+        system = self._make_system(investment=0.0, opex_annual=opex_annual, technical_lifetime=40.0)
+        calc = CostCalculator(system)
+        eac = calc.calculate_eac(discount_rate=5.0)
+
+        self.assertAlmostEqual(eac, opex_annual, places=10)
+
+    def test_npv_opex_end_of_period_discounting(self) -> None:
+        """NPV discounts OPEX using end-of-period convention: year t at (1+r)^t, t=1..n.
+
+        For a single asset with no CAPEX, r=10%, n=3 years, OPEX=1000/yr:
+            NPV = 1000/1.1^1 + 1000/1.1^2 + 1000/1.1^3
+                = 909.09 + 826.45 + 751.31 = 2486.85
+        A start-of-period sum (t=0..2) would give a different result:
+            1000/1.1^0 + 1000/1.1^1 + 1000/1.1^2 = 2735.54
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        system = self._make_system(investment=0.0, opex_annual=1_000.0, technical_lifetime=40.0)
+        calc = CostCalculator(system)
+        npv = calc.calculate_npv(system_lifetime=3.0, discount_rate=10.0)
+
+        r = 0.10
+        expected = sum(1_000.0 / (1 + r) ** t for t in range(1, 4))
+        self.assertAlmostEqual(npv, expected, places=6)
+
+    def test_npv_fractional_system_lifetime_prorates_final_year(self) -> None:
+        """NPV with a fractional system_lifetime prorates the final partial year of OPEX.
+
+        For system_lifetime=3.5, r=10%, OPEX=1000/yr:
+            NPV = 1000/1.1^1 + 1000/1.1^2 + 1000/1.1^3 + 0.5*1000/1.1^4
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        system = self._make_system(investment=0.0, opex_annual=1_000.0, technical_lifetime=40.0)
+        calc = CostCalculator(system)
+        npv = calc.calculate_npv(system_lifetime=3.5, discount_rate=10.0)
+
+        r = 0.10
+        expected = sum(1_000.0 / (1 + r) ** t for t in range(1, 4))
+        expected += 0.5 * 1_000.0 / (1 + r) ** 4
+        self.assertAlmostEqual(npv, expected, places=6)
+
+    def test_npv_zero_technical_lifetime_raises(self) -> None:
+        """NPV raises CalculationError when any asset has technical_lifetime <= 0."""
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+        from kpicalculator.exceptions import CalculationError
+
+        system = self._make_system(technical_lifetime=0.0)
+        calc = CostCalculator(system)
+
+        with self.assertRaises(CalculationError):
+            calc.calculate_npv(system_lifetime=30.0)
+
+    def test_eac_zero_technical_lifetime_raises(self) -> None:
+        """EAC raises CalculationError when any asset has technical_lifetime <= 0."""
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+        from kpicalculator.exceptions import CalculationError
+
+        system = self._make_system(technical_lifetime=0.0)
+        calc = CostCalculator(system)
+
+        with self.assertRaises(CalculationError):
+            calc.calculate_eac()
+
+    def test_tco_zero_technical_lifetime_raises(self) -> None:
+        """TCO raises CalculationError when any asset has technical_lifetime <= 0."""
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+        from kpicalculator.exceptions import CalculationError
+
+        system = self._make_system(technical_lifetime=0.0)
+        calc = CostCalculator(system)
+
+        with self.assertRaises(CalculationError):
+            calc.calculate_tco(system_lifetime=30.0)
+
+    def test_invalid_system_lifetime_raises_at_calculator_level(self) -> None:
+        """Each calculator method raises CalculationError for system_lifetime <= 0."""
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+        from kpicalculator.exceptions import CalculationError
+
+        calc = CostCalculator(self._make_system())
+
+        for method, kwargs in [
+            (calc.calculate_npv, {}),
+            (calc.calculate_lcoe, {}),
+            (calc.calculate_tco, {}),
+        ]:
+            with self.subTest(method=method.__name__, system_lifetime=0.0):
+                with self.assertRaises(CalculationError):
+                    method(system_lifetime=0.0, **kwargs)
+            with self.subTest(method=method.__name__, system_lifetime=-1.0):
+                with self.assertRaises(CalculationError):
+                    method(system_lifetime=-1.0, **kwargs)
+
+    def test_calculate_all_kpis_invalid_inputs_raise(self) -> None:
+        """calculate_all_kpis() raises ValueError for invalid system_lifetime or discount_rate."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))
+
+        with self.assertRaisesRegex(ValueError, "system_lifetime must be positive"):
+            kpi_manager.calculate_all_kpis(system_lifetime=0.0)
+
+        with self.assertRaisesRegex(ValueError, "system_lifetime must be positive"):
+            kpi_manager.calculate_all_kpis(system_lifetime=-1.0)
+
+        with self.assertRaisesRegex(ValueError, "discount_rate must be between 0 and 100"):
+            kpi_manager.calculate_all_kpis(discount_rate=-1.0)
+
+        with self.assertRaisesRegex(ValueError, "discount_rate must be between 0 and 100"):
+            kpi_manager.calculate_all_kpis(discount_rate=101.0)
+
+    def test_calculate_all_kpis_zero_discount_rate(self) -> None:
+        """calculate_all_kpis() accepts discount_rate=0 and EAC is positive."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0, discount_rate=0.0)
+
+        self.assertIn("eac", results["costs"])
+        self.assertIsInstance(results["costs"]["eac"], float)
+        self.assertGreaterEqual(results["costs"]["eac"], 0.0)
+
+    def test_eac_present_in_calculate_all_kpis_results(self) -> None:
+        """calculate_all_kpis() result dict includes 'eac' key under costs."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30)
+
+        self.assertIn("eac", results["costs"])
+        self.assertIsInstance(results["costs"]["eac"], float)
+        self.assertGreater(results["costs"]["eac"], 0.0)
+
+    # --- TCO tests ---
+
+    def test_eac_at_zero_discount_rate_is_straight_line_depreciation_plus_opex(self) -> None:
+        """At r=0, EAC = CAPEX / TL + annual_opex (straight-line depreciation).
+
+        EAC no longer relates to NPV or system_lifetime — it is purely per-asset.
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 100_000.0
+        opex_annual = 5_000.0
+        technical_lifetime = 40.0
+        system = self._make_system(
+            investment=investment, opex_annual=opex_annual, technical_lifetime=technical_lifetime
+        )
+        calc = CostCalculator(system)
+        eac = calc.calculate_eac(discount_rate=0.0)
+
+        expected = investment / technical_lifetime + opex_annual
+        self.assertAlmostEqual(eac, expected, places=10)
+
+    def test_tco_zero_discount_rate_equals_npv(self) -> None:
+        """At 0% discount rate, TCO == NPV for any replacement ratio.
+
+        Both NPV and TCO (default) use ceil for replacement counting, so they agree
+        exactly at r=0 — including fractional ratios like technical_lifetime=20,
+        system_lifetime=30 where ceil(1.5) = 2 for both.
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 100_000.0
+        opex_annual = 5_000.0
+        system_lifetime = 30.0
+
+        for technical_lifetime in [40.0, 20.0, 10.0]:
+            with self.subTest(technical_lifetime=technical_lifetime):
+                system = self._make_system(
+                    investment=investment,
+                    opex_annual=opex_annual,
+                    technical_lifetime=technical_lifetime,
+                )
+                calc = CostCalculator(system)
+                npv_zero = calc.calculate_npv(system_lifetime, discount_rate=0.0)
+                tco = calc.calculate_tco(system_lifetime)
+                self.assertAlmostEqual(tco, npv_zero, places=6)
+
+    def test_tco_default_uses_ceil(self) -> None:
+        """Default TCO uses ceil(n/technical_lifetime) — the financially exact replacement count.
+
+        With technical_lifetime=10 and system_lifetime=30: ceil(30/10) = 3.
+        With technical_lifetime=20 and system_lifetime=30: ceil(30/20) = 2
+        (you must buy a second asset at year 20 to keep the system running).
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 50_000.0
+        system_lifetime = 30.0
+
+        # Exact integer ratio — ceil and continuous agree
+        system_exact = self._make_system(
+            investment=investment, opex_annual=0.0, technical_lifetime=10.0
+        )
+        tco_exact = CostCalculator(system_exact).calculate_tco(system_lifetime)
+        self.assertAlmostEqual(tco_exact, 3.0 * investment, places=2)
+
+        # Fractional ratio — ceil gives 2, continuous would give 1.5
+        system_frac = self._make_system(
+            investment=investment, opex_annual=0.0, technical_lifetime=20.0
+        )
+        tco_frac = CostCalculator(system_frac).calculate_tco(system_lifetime)
+        self.assertAlmostEqual(tco_frac, 2.0 * investment, places=2)
+
+    def test_tco_continuous_factor_uses_max_fraction(self) -> None:
+        """round_up_replacement=False uses max(1, n/technical_lifetime) for optimizer comparisons.
+
+        With technical_lifetime=20 and system_lifetime=30: continuous factor = 1.5,
+        matching optimizers such as MESIDO's MinimizeTCO goal (which uses this
+        approximation to keep the objective smooth and differentiable).
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 50_000.0
+        system_lifetime = 30.0
+        system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=20.0)
+        calc = CostCalculator(system)
+
+        tco_default = calc.calculate_tco(system_lifetime)
+        tco_continuous = calc.calculate_tco(system_lifetime, round_up_replacement=False)
+
+        self.assertAlmostEqual(tco_default, 2.0 * investment, places=2)
+        self.assertAlmostEqual(tco_continuous, 1.5 * investment, places=2)
+
+    def test_tco_system_shorter_than_technical_lifetime_counts_one(self) -> None:
+        """When system_lifetime < technical_lifetime, exactly one purchase is counted.
+
+        ceil(10/40) = 1 — the asset is bought once and not replaced.
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        investment = 80_000.0
+        system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=40.0)
+        tco = CostCalculator(system).calculate_tco(system_lifetime=10.0)
+        self.assertAlmostEqual(tco, investment, places=2)
+
+    def test_tco_greater_than_npv_with_positive_discount_rate(self) -> None:
+        """TCO >= NPV when discount_rate > 0.
+
+        NPV discounts future costs to present value (making them smaller), while
+        TCO sums them at face value.  So TCO >= NPV for any positive discount rate.
+        """
+        from kpicalculator.calculators.cost_calculator import CostCalculator
+
+        system_lifetime = 30.0
+        system = self._make_system(
+            investment=100_000.0, opex_annual=5_000.0, technical_lifetime=40.0
+        )
+        calc = CostCalculator(system)
+
+        tco = calc.calculate_tco(system_lifetime)
+        npv = calc.calculate_npv(system_lifetime, discount_rate=5.0)
+
+        self.assertGreaterEqual(tco, npv)
+
+    def test_tco_present_in_calculate_all_kpis_results(self) -> None:
+        """calculate_all_kpis() result dict includes 'tco' key under costs."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30)
+
+        self.assertIn("tco", results["costs"])
+        self.assertIsInstance(results["costs"]["tco"], float)
+        self.assertGreater(results["costs"]["tco"], 0.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/unit_test/test_kpi_calculator.py
+++ b/unit_test/test_kpi_calculator.py
@@ -291,6 +291,80 @@ class DataFrameTimeSeriesTest(unittest.TestCase):
         self.assertIn(expected_error, validation.errors)
 
 
+class SimulatorFieldMappingTest(unittest.TestCase):
+    """Test that simulator-core field names map to the correct KPI calculator categories.
+
+    Each test loads a DataFrame with a single simulator-core field name and asserts that
+    the corresponding KPI category (consumption, production, or conversion) is non-zero.
+
+    Asset IDs from Unit_test_ESDL.esdl:
+      CONSUMER    a5243809-0077-46e5-a0ea-09aa486f5e96  GenericConsumer_a524
+      PRODUCER    b98655e1-9e81-4878-875f-c1f946cc5d6c  GenericProducer_b986
+      CONVERSION  743b1ff1-0ee4-4c6c-ba5f-e7ebf169348c  GasHeater_743b
+    """
+
+    TIMESTEPS = 24
+    POWER_W = 100_000.0
+    CONSUMER_ID = "a5243809-0077-46e5-a0ea-09aa486f5e96"
+    PRODUCER_ID = "b98655e1-9e81-4878-875f-c1f946cc5d6c"
+    CONVERSION_ID = "743b1ff1-0ee4-4c6c-ba5f-e7ebf169348c"
+
+    def setUp(self) -> None:
+        self.esdl_file = str(DATA_DIR / "Unit_test_ESDL.esdl")
+
+    def _make_dataframe(self, columns: dict) -> pd.DataFrame:
+        index = pd.date_range("2024-01-01T00:00:00", periods=self.TIMESTEPS, freq="h")
+        return pd.DataFrame(columns, index=index)
+
+    def _load_and_calculate(self, asset_id: str, column_name: str) -> dict:
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(
+            self.esdl_file,
+            timeseries_dataframes={
+                asset_id: self._make_dataframe({column_name: [self.POWER_W] * self.TIMESTEPS})
+            },
+        )
+        return kpi_manager.calculate_all_kpis()
+
+    def test__heat_power_primary__maps_to_consumption(self) -> None:
+        # heat_power_primary is in CONSUMPTION_FIELDS; load it on a CONSUMER asset
+        results = self._load_and_calculate(self.CONSUMER_ID, "heat_power_primary")
+        self.assertGreater(
+            results["energy"]["consumption"],
+            0.0,
+            "heat_power_primary must contribute to energy consumption",
+        )
+
+    def test__heat_power_secondary__maps_to_production(self) -> None:
+        # heat_power_secondary is in PRODUCTION_FIELDS; load it on a PRODUCER asset
+        results = self._load_and_calculate(self.PRODUCER_ID, "heat_power_secondary")
+        self.assertGreater(
+            results["energy"]["production"],
+            0.0,
+            "heat_power_secondary must contribute to energy production",
+        )
+
+    def test__electricity_consumption__stored_as_named_time_series(self) -> None:
+        # electricity_consumption is in CONVERSION_FIELDS; load it on a CONVERSION asset
+        # and verify it is stored (recognised) in the time series for that asset.
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(
+            self.esdl_file,
+            timeseries_dataframes={
+                self.CONVERSION_ID: self._make_dataframe(
+                    {"electricity_consumption": [self.POWER_W] * self.TIMESTEPS}
+                )
+            },
+        )
+        kpi_manager.calculate_all_kpis()
+        asset = next(a for a in kpi_manager.energy_system.assets if a.id == self.CONVERSION_ID)
+        self.assertIn(
+            "electricity_consumption",
+            asset.time_series,
+            "electricity_consumption must be stored as a named time series on a CONVERSION asset",
+        )
+
+
 class TestTimeSeriesManagerValidation(unittest.TestCase):
     """Tests for uncovered validation branches in TimeSeriesManager."""
 

--- a/unit_test/test_kpi_calculator.py
+++ b/unit_test/test_kpi_calculator.py
@@ -14,6 +14,13 @@ DATA_DIR = TEST_DIR / "data"
 from esdl import esdl  # noqa: E402
 
 from kpicalculator import KpiManager  # noqa: E402
+from kpicalculator.adapters.common_model import (  # noqa: E402
+    Asset,
+    AssetType,
+    EnergySystem,
+    TimeSeries,
+)
+from kpicalculator.calculators.financial_calculator import FinancialCalculator  # noqa: E402
 
 
 class NewKpiCalculatorTest(unittest.TestCase):
@@ -32,13 +39,16 @@ class NewKpiCalculatorTest(unittest.TestCase):
         results = self.kpi_manager.calculate_all_kpis(system_lifetime=40)
 
         # Check that results contain expected keys
-        self.assertIn("costs", results)
+        self.assertIn("financials", results)
         self.assertIn("energy", results)
         self.assertIn("emissions", results)
 
         # Check specific values (using ESDL costInformation only)
         self.assertAlmostEqual(
-            results["costs"]["capex"]["All"], 107900.03, places=2, msg="Total CAPEX is incorrect"
+            results["financials"]["capex"]["All"],
+            107900.03,
+            places=2,
+            msg="Total CAPEX is incorrect",
         )
 
         self.assertAlmostEqual(
@@ -124,8 +134,8 @@ class EsdlStringLoadingTest(unittest.TestCase):
         # Compare KPI results - should be identical
         string_results = string_manager.calculate_all_kpis(system_lifetime=40)
         self.assertAlmostEqual(
-            file_results["costs"]["capex"]["All"],
-            string_results["costs"]["capex"]["All"],
+            file_results["financials"]["capex"]["All"],
+            string_results["financials"]["capex"]["All"],
             places=2,
             msg="CAPEX mismatch between file and string loading",
         )
@@ -588,8 +598,10 @@ class EsdlKpiExportIntegrationTest(unittest.TestCase):
 
         self.assertIsNotNone(capex_value)
         self.assertIsNotNone(opex_value)
-        self.assertAlmostEqual(capex_value, self.kpi_results["costs"]["capex"]["All"], places=2)
-        self.assertAlmostEqual(opex_value, self.kpi_results["costs"]["opex"]["All"], places=2)
+        self.assertAlmostEqual(
+            capex_value, self.kpi_results["financials"]["capex"]["All"], places=2
+        )
+        self.assertAlmostEqual(opex_value, self.kpi_results["financials"]["opex"]["All"], places=2)
 
     def test_kpi_structure_compliance(self) -> None:
         """Every exported KPI follows the ESDL DistributionKPI schema."""
@@ -649,8 +661,8 @@ class EsdlKpiExportIntegrationTest(unittest.TestCase):
             seen.add(kpi.id)
 
 
-class CostCalculatorEdgeCaseTest(unittest.TestCase):
-    """Unit tests for NPV and LCOE edge cases in CostCalculator.
+class FinancialCalculatorEdgeCaseTest(unittest.TestCase):
+    """Unit tests for NPV and LCOE edge cases in FinancialCalculator.
 
     These tests use a minimal synthetic EnergySystem — no file I/O, no ESDL parsing —
     so they are fast and isolated.  Each test pins a specific mathematical edge case
@@ -662,9 +674,7 @@ class CostCalculatorEdgeCaseTest(unittest.TestCase):
         investment: float = 100_000.0,
         opex_annual: float = 5_000.0,
         technical_lifetime: float = 40.0,
-    ) -> "EnergySystem":  # noqa: F821  # imported below inside method
-        from kpicalculator.adapters.common_model import Asset, AssetType, EnergySystem
-
+    ) -> EnergySystem:
         asset = Asset(
             id="test_asset",
             name="Test Asset",
@@ -684,14 +694,12 @@ class CostCalculatorEdgeCaseTest(unittest.TestCase):
         so NPV reduces to: CAPEX (one investment) + OPEX * system_lifetime.
         This is the social cost accounting approach used in some public-sector projects.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
-
         system_lifetime = 30.0
         investment = 100_000.0
         opex_annual = 5_000.0
         system = self._make_system(investment=investment, opex_annual=opex_annual)
 
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
         npv = calc.calculate_npv(system_lifetime, discount_rate=0.0)
 
         # At 0%: one CAPEX replacement (ceil(30/40)=1) + 30 years of OPEX
@@ -704,10 +712,9 @@ class CostCalculatorEdgeCaseTest(unittest.TestCase):
         Discounting future costs makes them worth less today, so discounted NPV < undiscounted NPV.
         This confirms that the discount factor is actually applied and not ignored.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         system = self._make_system()
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         npv_zero = calc.calculate_npv(30.0, discount_rate=0.0)
         npv_five = calc.calculate_npv(30.0, discount_rate=5.0)
@@ -721,11 +728,10 @@ class CostCalculatorEdgeCaseTest(unittest.TestCase):
         the project horizon.  This represents a short-horizon project (e.g. a 10-year
         concession) using a long-lived asset (40-year boiler).
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 100_000.0
         system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=40.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         # With no OPEX and 0% discount, NPV = exactly one investment
         npv = calc.calculate_npv(system_lifetime=10.0, discount_rate=0.0)
@@ -738,11 +744,10 @@ class CostCalculatorEdgeCaseTest(unittest.TestCase):
         ceil(50 / 40) = 2 replacements (year 0 and year 40).  The second replacement
         is discounted; this test confirms the replacement loop runs correctly.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 100_000.0
         system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=40.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         # At 0% discount: NPV = 2 * investment (no discounting, two replacements)
         npv = calc.calculate_npv(system_lifetime=50.0, discount_rate=0.0)
@@ -755,18 +760,17 @@ class CostCalculatorEdgeCaseTest(unittest.TestCase):
         Without time series, energy = 0.  Dividing NPV by zero energy would be
         undefined; the calculator must return 0.0 rather than raising ZeroDivisionError.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         system = self._make_system()
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         lcoe = calc.calculate_lcoe(system_lifetime=30.0)
 
         self.assertEqual(lcoe, 0.0)
 
 
-class CostCalculatorUnitBranchTest(unittest.TestCase):
-    """Unit tests for the per-unit cost calculation branches in CostCalculator.
+class FinancialCalculatorUnitBranchTest(unittest.TestCase):
+    """Unit tests for the per-unit cost calculation branches in FinancialCalculator.
 
     The integration tests in NewKpiCalculatorTest only exercise flat EUR costs because
     the ESDL fixture uses EUR everywhere.  These tests construct Asset objects directly
@@ -799,18 +803,14 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
     _HOURS = 8_760  # one year of hourly data
     _TIME_STEP = 3_600.0  # 1 hour in seconds
 
-    def _make_system(self, asset: "Asset") -> "EnergySystem":  # noqa: F821
-        from kpicalculator.adapters.common_model import EnergySystem
-
+    def _make_system(self, asset: Asset) -> EnergySystem:
         return EnergySystem(
             name="Test System",
             assets=[asset],
             unit_conversion=dict(self._UNIT_CONVERSION),
         )
 
-    def _make_asset(self, **kwargs) -> "Asset":  # noqa: F821
-        from kpicalculator.adapters.common_model import Asset, AssetType
-
+    def _make_asset(self, **kwargs) -> Asset:
         defaults = dict(
             id="asset_1",
             name="Test Asset",
@@ -823,10 +823,8 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         defaults.update(kwargs)
         return Asset(**defaults)
 
-    def _make_hourly_time_series(self, power_w: float) -> "TimeSeries":  # noqa: F821
+    def _make_hourly_time_series(self, power_w: float) -> TimeSeries:
         """One year of constant hourly power values."""
-        from kpicalculator.adapters.common_model import TimeSeries
-
         return TimeSeries(
             time_step=self._TIME_STEP,
             values=[power_w] * self._HOURS,
@@ -842,60 +840,54 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         A 500 kW asset at 200 EUR/kW should cost 100,000 EUR.
         The EUR/kW factor converts watts → kilowatts (÷1000).
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(investment_cost=self._COST_RATE, investment_cost_unit="EUR/kW")
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = self._COST_RATE * self._POWER_W * self._UNIT_CONVERSION["EUR/kW"]
         self.assertAlmostEqual(calc._calculate_investment_cost(asset), expected, places=4)
 
     def test_investment_cost_eur_mw(self) -> None:
         """EUR/MW investment cost scales with power, using a megawatt conversion factor."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(investment_cost=self._COST_RATE, investment_cost_unit="EUR/MW")
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = self._COST_RATE * self._POWER_W * self._UNIT_CONVERSION["EUR/MW"]
         self.assertAlmostEqual(calc._calculate_investment_cost(asset), expected, places=4)
 
     def test_investment_cost_eur_per_m(self) -> None:
         """EUR/m investment cost scales with asset length (e.g. pipeline cost per metre)."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(investment_cost=self._COST_RATE, investment_cost_unit="EUR/m")
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = self._COST_RATE * self._LENGTH_M * self._UNIT_CONVERSION["EUR/m"]
         self.assertAlmostEqual(calc._calculate_investment_cost(asset), expected, places=4)
 
     def test_investment_cost_eur_per_km(self) -> None:
         """EUR/km investment cost scales with length and converts metres to kilometres."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(investment_cost=self._COST_RATE, investment_cost_unit="EUR/km")
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = self._COST_RATE * self._LENGTH_M * self._UNIT_CONVERSION["EUR/km"]
         self.assertAlmostEqual(calc._calculate_investment_cost(asset), expected, places=4)
 
     def test_investment_cost_eur_m3(self) -> None:
         """EUR/m³ investment cost scales with storage volume (no unit-conversion factor)."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(investment_cost=self._COST_RATE, investment_cost_unit="EUR/m3")
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = self._COST_RATE * self._VOLUME_M3
         self.assertAlmostEqual(calc._calculate_investment_cost(asset), expected, places=4)
 
     def test_investment_cost_unknown_unit_returns_zero(self) -> None:
         """An unrecognised investment cost unit returns 0.0 rather than raising."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(investment_cost=self._COST_RATE, investment_cost_unit="UNKNOWN")
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         self.assertEqual(calc._calculate_investment_cost(asset), 0.0)
 
@@ -905,30 +897,27 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
 
     def test_installation_cost_eur_kw(self) -> None:
         """EUR/kW installation cost applies the same power-scaling as investment cost."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(installation_cost=self._COST_RATE, installation_cost_unit="EUR/kW")
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = self._COST_RATE * self._POWER_W * self._UNIT_CONVERSION["EUR/kW"]
         self.assertAlmostEqual(calc._calculate_installation_cost(asset), expected, places=4)
 
     def test_installation_cost_eur_per_km(self) -> None:
         """EUR/km installation cost scales with length and converts metres to kilometres."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(installation_cost=self._COST_RATE, installation_cost_unit="EUR/km")
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = self._COST_RATE * self._LENGTH_M * self._UNIT_CONVERSION["EUR/km"]
         self.assertAlmostEqual(calc._calculate_installation_cost(asset), expected, places=4)
 
     def test_installation_cost_eur_m3(self) -> None:
         """EUR/m³ installation cost uses volume directly without a conversion factor."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(installation_cost=self._COST_RATE, installation_cost_unit="EUR/m3")
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         self.assertAlmostEqual(
             calc._calculate_installation_cost(asset), self._COST_RATE * self._VOLUME_M3, places=4
@@ -944,7 +933,6 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         With 1000 EUR investment and 2% annual OPEX, the cost is 20 EUR/yr.
         This unit is common for O&M modelled as a percentage of total capital cost.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         capex = 1_000.0
         opex_pct = 2.0  # 2%
@@ -954,20 +942,19 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
             fixed_operational_cost=opex_pct,
             fixed_operational_cost_unit="% OF CAPEX",
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = capex * opex_pct * self._UNIT_CONVERSION["% OF CAPEX"]
         self.assertAlmostEqual(calc._calculate_fixed_operational_cost(asset), expected, places=4)
 
     def test_fixed_operational_cost_eur_mw(self) -> None:
         """EUR/MW fixed operational cost scales with asset power."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(
             fixed_operational_cost=self._COST_RATE,
             fixed_operational_cost_unit="EUR/MW",
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = self._COST_RATE * self._POWER_W * self._UNIT_CONVERSION["EUR/MW"]
         self.assertAlmostEqual(calc._calculate_fixed_operational_cost(asset), expected, places=4)
@@ -982,7 +969,6 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         One year of 100 kW constant output at 10 EUR/MWh should give a positive
         annual cost.  This confirms the time-series integration path is reached.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         power_w = 100_000.0  # 100 kW
         cost_rate = 10.0  # EUR/MWh
@@ -992,7 +978,7 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
             variable_operational_cost_unit="EUR/MWh",
             time_series={"key": ts},
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         result = calc._calculate_variable_operational_cost(asset)
         self.assertGreater(result, 0.0)
@@ -1004,7 +990,6 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         A non-zero result confirms both branches of the EUR/kWh | EUR/MWh condition
         are reachable.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         power_w = 100_000.0
         ts = self._make_hourly_time_series(power_w)
@@ -1013,7 +998,7 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
             variable_operational_cost_unit="EUR/kWh",
             time_series={"key": ts},
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         self.assertGreater(calc._calculate_variable_operational_cost(asset), 0.0)
 
@@ -1023,14 +1008,13 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         Without energy data the energy integral is undefined; returning 0.0 avoids
         a ZeroDivisionError and is consistent with the zero-energy edge case contract.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(
             variable_operational_cost=10.0,
             variable_operational_cost_unit="EUR/MWh",
             time_series={},
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         self.assertEqual(calc._calculate_variable_operational_cost(asset), 0.0)
 
@@ -1042,9 +1026,6 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         must be scaled down by COP to reflect actual cost per delivered MWh.
         A higher COP yields a lower cost for the same rate and energy output.
         """
-        from kpicalculator.adapters.common_model import AssetType
-        from kpicalculator.calculators.cost_calculator import CostCalculator
-
         power_w = 100_000.0
         ts = self._make_hourly_time_series(power_w)
 
@@ -1064,8 +1045,8 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
             time_series={"key": ts},
         )
 
-        calc2 = CostCalculator(self._make_system(asset_cop2))
-        calc4 = CostCalculator(self._make_system(asset_cop4))
+        calc2 = FinancialCalculator(self._make_system(asset_cop2))
+        calc4 = FinancialCalculator(self._make_system(asset_cop4))
 
         # Higher COP → lower variable cost (energy delivered per unit consumed is higher)
         self.assertGreater(
@@ -1079,7 +1060,6 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
 
     def test_fixed_maintenance_cost_percent_of_capex(self) -> None:
         """% OF CAPEX fixed maintenance cost is a fraction of total capital cost."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         capex = 2_000.0
         maint_pct = 1.5
@@ -1089,20 +1069,19 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
             fixed_maintenance_cost=maint_pct,
             fixed_maintenance_cost_unit="% OF CAPEX",
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = capex * maint_pct * self._UNIT_CONVERSION["% OF CAPEX"]
         self.assertAlmostEqual(calc._calculate_fixed_maintenance_cost(asset), expected, places=4)
 
     def test_fixed_maintenance_cost_eur_mw(self) -> None:
         """EUR/MW fixed maintenance cost scales with asset rated power."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(
             fixed_maintenance_cost=self._COST_RATE,
             fixed_maintenance_cost_unit="EUR/MW",
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         expected = self._COST_RATE * self._POWER_W * self._UNIT_CONVERSION["EUR/MW"]
         self.assertAlmostEqual(calc._calculate_fixed_maintenance_cost(asset), expected, places=4)
@@ -1117,7 +1096,6 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         The variable maintenance path is structurally identical to variable OPEX;
         this test confirms the separate maintenance method is also exercised.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         power_w = 100_000.0
         ts = self._make_hourly_time_series(power_w)
@@ -1126,7 +1104,7 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
             variable_maintenance_cost_unit="EUR/MWh",
             time_series={"key": ts},
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         self.assertGreater(calc._calculate_variable_maintenance_cost(asset), 0.0)
 
@@ -1137,9 +1115,6 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         contain the geothermal COP branch independently.  This test covers the maintenance
         version to ensure both are tested.
         """
-        from kpicalculator.adapters.common_model import AssetType
-        from kpicalculator.calculators.cost_calculator import CostCalculator
-
         power_w = 100_000.0
         ts = self._make_hourly_time_series(power_w)
         asset = self._make_asset(
@@ -1149,21 +1124,20 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
             variable_maintenance_cost_unit="EUR/MWh",
             time_series={"key": ts},
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         # With COP=3 the cost must be positive (COP > 0 branch executed)
         self.assertGreater(calc._calculate_variable_maintenance_cost(asset), 0.0)
 
     def test_variable_maintenance_cost_no_time_series_returns_zero(self) -> None:
         """EUR/MWh variable maintenance cost returns 0.0 with no time series data."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(
             variable_maintenance_cost=5.0,
             variable_maintenance_cost_unit="EUR/MWh",
             time_series={},
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         self.assertEqual(calc._calculate_variable_maintenance_cost(asset), 0.0)
 
@@ -1171,12 +1145,12 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
         self, method_name: str, unit_field: str, unit_value: str, cost_field: str
     ) -> None:
         """Helper: verify that an unsupported unit logs a warning and returns 0.0."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         asset = self._make_asset(**{cost_field: 5.0, unit_field: unit_value})
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
-        with self.assertLogs("kpicalculator.calculators.cost_calculator", level="WARNING") as cm:
+        logger_name = "kpicalculator.calculators.financial_calculator"
+        with self.assertLogs(logger_name, level="WARNING") as cm:
             result = getattr(calc, method_name)(asset)
 
         self.assertEqual(result, 0.0)
@@ -1241,7 +1215,6 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
 
     def test_energy_calculator_zero_duration_returns_zero(self) -> None:
         """A time series with time_step=0 must not crash with ZeroDivisionError."""
-        from kpicalculator.adapters.common_model import AssetType, TimeSeries
         from kpicalculator.calculators.energy_calculator import EnergyCalculator
 
         ts = TimeSeries(time_step=0.0, values=[100.0] * 10)
@@ -1255,7 +1228,6 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
 
     def test_emission_calculator_zero_duration_returns_zero(self) -> None:
         """A time series with time_step=0 must not crash with ZeroDivisionError."""
-        from kpicalculator.adapters.common_model import AssetType, TimeSeries
         from kpicalculator.calculators.emission_calculator import EmissionCalculator
 
         ts = TimeSeries(time_step=0.0, values=[100.0] * 10)
@@ -1268,18 +1240,15 @@ class CostCalculatorUnitBranchTest(unittest.TestCase):
 
         self.assertEqual(calc.get_total_emissions(), 0.0)
 
-    def test_cost_calculator_zero_duration_returns_zero(self) -> None:
+    def test_financial_calculator_zero_duration_returns_zero(self) -> None:
         """Variable cost with time_step=0 must not crash with ZeroDivisionError."""
-        from kpicalculator.adapters.common_model import TimeSeries
-        from kpicalculator.calculators.cost_calculator import CostCalculator
-
         ts = TimeSeries(time_step=0.0, values=[100.0] * 10)
         asset = self._make_asset(
             variable_operational_cost=5.0,
             variable_operational_cost_unit="EUR/MWh",
             time_series={"heat_supplied": ts},
         )
-        calc = CostCalculator(self._make_system(asset))
+        calc = FinancialCalculator(self._make_system(asset))
 
         self.assertEqual(calc._calculate_variable_operational_cost(asset), 0.0)
 
@@ -1298,7 +1267,7 @@ class BaseAdapterValidationTest(unittest.TestCase):
 
         return EsdlAdapter()
 
-    def _make_asset(self, **kwargs) -> "Asset":  # noqa: F821
+    def _make_asset(self, **kwargs) -> "Asset":
         from kpicalculator.adapters.common_model import Asset, AssetType
 
         defaults = dict(
@@ -1311,7 +1280,7 @@ class BaseAdapterValidationTest(unittest.TestCase):
         defaults.update(kwargs)
         return Asset(**defaults)
 
-    def _make_system(self, assets: list) -> "EnergySystem":  # noqa: F821
+    def _make_system(self, assets: list) -> "EnergySystem":
         from kpicalculator.adapters.common_model import EnergySystem
 
         return EnergySystem(name="Test System", assets=assets)
@@ -1385,7 +1354,7 @@ class BaseAdapterValidationTest(unittest.TestCase):
 
 
 class EacTcoCalculatorTest(unittest.TestCase):
-    """Unit tests for EAC and TCO calculations in CostCalculator.
+    """Unit tests for EAC and TCO calculations in FinancialCalculator.
 
     Uses a minimal synthetic EnergySystem — no file I/O, no ESDL parsing — so
     tests are fast and isolated.  Each test pins a specific mathematical property
@@ -1397,7 +1366,7 @@ class EacTcoCalculatorTest(unittest.TestCase):
         investment: float = 100_000.0,
         opex_annual: float = 5_000.0,
         technical_lifetime: float = 40.0,
-    ) -> "EnergySystem":  # noqa: F821
+    ) -> "EnergySystem":
         from kpicalculator.adapters.common_model import Asset, AssetType, EnergySystem
 
         asset = Asset(
@@ -1420,26 +1389,24 @@ class EacTcoCalculatorTest(unittest.TestCase):
         At r=0 the annuity degenerates to CAPEX / TL. For TL=1, annualized_CAPEX = CAPEX.
         Ported from mesido Assertion 4.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 1_000.0
         system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=1.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
         eac = calc.calculate_eac(discount_rate=0.0)
 
         self.assertAlmostEqual(eac, investment, places=10)
 
     def test_annuity_factor_10pct_discount_rate_tl1(self) -> None:
-        """annuity_factor(r=0.10, TL=1) == 1.1: annualized_CAPEX = CAPEX × 1.1.
+        """annuity_factor(r=0.10, TL=1) == 1.1: annualized_CAPEX = CAPEX x 1.1.
 
         For TL=1: factor = r / (1 - (1+r)^-1) = 1+r = 1.1.
         Ported from mesido Assertion 4.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 1_000.0
         system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=1.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
         eac = calc.calculate_eac(discount_rate=10.0)
 
         self.assertAlmostEqual(eac, investment * 1.1, places=10)
@@ -1451,9 +1418,8 @@ class EacTcoCalculatorTest(unittest.TestCase):
 
         For a single asset: investment=100,000, r=5%, TL=40yr:
             annuity_factor = 0.05 / (1 - 1.05^-40)
-            EAC = investment × annuity_factor
+            EAC = investment x annuity_factor
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 100_000.0
         technical_lifetime = 40.0
@@ -1461,7 +1427,7 @@ class EacTcoCalculatorTest(unittest.TestCase):
         system = self._make_system(
             investment=investment, opex_annual=0.0, technical_lifetime=technical_lifetime
         )
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
         eac = calc.calculate_eac(discount_rate=discount_rate)
 
         r = discount_rate / 100.0
@@ -1470,24 +1436,22 @@ class EacTcoCalculatorTest(unittest.TestCase):
 
     def test_eac_zero_discount_rate_equals_capex_divided_by_technical_lifetime(self) -> None:
         """At r=0, EAC = CAPEX / technical_lifetime (simple straight-line depreciation)."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 100_000.0
         technical_lifetime = 40.0
         system = self._make_system(
             investment=investment, opex_annual=0.0, technical_lifetime=technical_lifetime
         )
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
         eac = calc.calculate_eac(discount_rate=0.0)
 
         self.assertAlmostEqual(eac, investment / technical_lifetime, places=10)
 
     def test_eac_higher_discount_rate_yields_higher_eac(self) -> None:
         """Higher discount rate produces higher EAC (higher annuity factor)."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         system = self._make_system()
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         eac_low = calc.calculate_eac(discount_rate=2.0)
         eac_high = calc.calculate_eac(discount_rate=8.0)
@@ -1505,7 +1469,6 @@ class EacTcoCalculatorTest(unittest.TestCase):
         import math
 
         from kpicalculator.adapters.common_model import Asset, AssetType, EnergySystem
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 100_000.0
         technical_lifetime = 40.0
@@ -1538,8 +1501,10 @@ class EacTcoCalculatorTest(unittest.TestCase):
         )
         system_no_rate = EnergySystem(name="System B", assets=[asset_no_rate])
 
-        eac_asset_rate = CostCalculator(system_with_rate).calculate_eac(discount_rate=fallback_rate)
-        eac_fallback = CostCalculator(system_no_rate).calculate_eac(discount_rate=asset_rate)
+        eac_asset_rate = FinancialCalculator(system_with_rate).calculate_eac(
+            discount_rate=fallback_rate
+        )
+        eac_fallback = FinancialCalculator(system_no_rate).calculate_eac(discount_rate=asset_rate)
 
         # Both should equal the annuity at asset_rate
         r = asset_rate / 100.0
@@ -1548,18 +1513,17 @@ class EacTcoCalculatorTest(unittest.TestCase):
         self.assertAlmostEqual(eac_asset_rate, eac_fallback, places=10)
 
         # Confirm it differs from what the fallback_rate would give
-        eac_at_fallback_rate = CostCalculator(system_no_rate).calculate_eac(
+        eac_at_fallback_rate = FinancialCalculator(system_no_rate).calculate_eac(
             discount_rate=fallback_rate
         )
         self.assertNotAlmostEqual(eac_asset_rate, eac_at_fallback_rate, places=2)
 
     def test_eac_opex_passed_through_directly(self) -> None:
         """EAC includes annual OPEX directly — OPEX is not annualized."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         opex_annual = 5_000.0
         system = self._make_system(investment=0.0, opex_annual=opex_annual, technical_lifetime=40.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
         eac = calc.calculate_eac(discount_rate=5.0)
 
         self.assertAlmostEqual(eac, opex_annual, places=10)
@@ -1573,10 +1537,9 @@ class EacTcoCalculatorTest(unittest.TestCase):
         A start-of-period sum (t=0..2) would give a different result:
             1000/1.1^0 + 1000/1.1^1 + 1000/1.1^2 = 2735.54
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         system = self._make_system(investment=0.0, opex_annual=1_000.0, technical_lifetime=40.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
         npv = calc.calculate_npv(system_lifetime=3.0, discount_rate=10.0)
 
         r = 0.10
@@ -1589,10 +1552,9 @@ class EacTcoCalculatorTest(unittest.TestCase):
         For system_lifetime=3.5, r=10%, OPEX=1000/yr:
             NPV = 1000/1.1^1 + 1000/1.1^2 + 1000/1.1^3 + 0.5*1000/1.1^4
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         system = self._make_system(investment=0.0, opex_annual=1_000.0, technical_lifetime=40.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
         npv = calc.calculate_npv(system_lifetime=3.5, discount_rate=10.0)
 
         r = 0.10
@@ -1602,43 +1564,39 @@ class EacTcoCalculatorTest(unittest.TestCase):
 
     def test_npv_zero_technical_lifetime_raises(self) -> None:
         """NPV raises CalculationError when any asset has technical_lifetime <= 0."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
         from kpicalculator.exceptions import CalculationError
 
         system = self._make_system(technical_lifetime=0.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         with self.assertRaises(CalculationError):
             calc.calculate_npv(system_lifetime=30.0)
 
     def test_eac_zero_technical_lifetime_raises(self) -> None:
         """EAC raises CalculationError when any asset has technical_lifetime <= 0."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
         from kpicalculator.exceptions import CalculationError
 
         system = self._make_system(technical_lifetime=0.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         with self.assertRaises(CalculationError):
             calc.calculate_eac()
 
     def test_tco_zero_technical_lifetime_raises(self) -> None:
         """TCO raises CalculationError when any asset has technical_lifetime <= 0."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
         from kpicalculator.exceptions import CalculationError
 
         system = self._make_system(technical_lifetime=0.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         with self.assertRaises(CalculationError):
             calc.calculate_tco(system_lifetime=30.0)
 
     def test_invalid_system_lifetime_raises_at_calculator_level(self) -> None:
         """Each calculator method raises CalculationError for system_lifetime <= 0."""
-        from kpicalculator.calculators.cost_calculator import CostCalculator
         from kpicalculator.exceptions import CalculationError
 
-        calc = CostCalculator(self._make_system())
+        calc = FinancialCalculator(self._make_system())
 
         for method, kwargs in [
             (calc.calculate_npv, {}),
@@ -1671,26 +1629,18 @@ class EacTcoCalculatorTest(unittest.TestCase):
             kpi_manager.calculate_all_kpis(discount_rate=101.0)
 
     def test_calculate_all_kpis_zero_discount_rate(self) -> None:
-        """calculate_all_kpis() accepts discount_rate=0 and EAC is positive."""
+        """calculate_all_kpis() accepts discount_rate=0; EAC equals straight-line depreciation."""
         esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
         kpi_manager = KpiManager()
         kpi_manager.load_from_esdl(str(esdl_file))
-        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0, discount_rate=0.0)
+        results_zero = kpi_manager.calculate_all_kpis(system_lifetime=30.0, discount_rate=0.0)
+        results_5pct = kpi_manager.calculate_all_kpis(system_lifetime=30.0, discount_rate=5.0)
 
-        self.assertIn("eac", results["costs"])
-        self.assertIsInstance(results["costs"]["eac"], float)
-        self.assertGreaterEqual(results["costs"]["eac"], 0.0)
-
-    def test_eac_present_in_calculate_all_kpis_results(self) -> None:
-        """calculate_all_kpis() result dict includes 'eac' key under costs."""
-        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
-        kpi_manager = KpiManager()
-        kpi_manager.load_from_esdl(str(esdl_file))
-        results = kpi_manager.calculate_all_kpis(system_lifetime=30)
-
-        self.assertIn("eac", results["costs"])
-        self.assertIsInstance(results["costs"]["eac"], float)
-        self.assertGreater(results["costs"]["eac"], 0.0)
+        self.assertIn("eac", results_zero["financials"])
+        self.assertIsInstance(results_zero["financials"]["eac"], float)
+        self.assertGreater(results_zero["financials"]["eac"], 0.0)
+        # At r=0 the annuity factor is 1/TL, so EAC is lower than at r=5%.
+        self.assertLess(results_zero["financials"]["eac"], results_5pct["financials"]["eac"])
 
     # --- TCO tests ---
 
@@ -1699,7 +1649,6 @@ class EacTcoCalculatorTest(unittest.TestCase):
 
         EAC no longer relates to NPV or system_lifetime — it is purely per-asset.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 100_000.0
         opex_annual = 5_000.0
@@ -1707,7 +1656,7 @@ class EacTcoCalculatorTest(unittest.TestCase):
         system = self._make_system(
             investment=investment, opex_annual=opex_annual, technical_lifetime=technical_lifetime
         )
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
         eac = calc.calculate_eac(discount_rate=0.0)
 
         expected = investment / technical_lifetime + opex_annual
@@ -1720,7 +1669,6 @@ class EacTcoCalculatorTest(unittest.TestCase):
         exactly at r=0 — including fractional ratios like technical_lifetime=20,
         system_lifetime=30 where ceil(1.5) = 2 for both.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 100_000.0
         opex_annual = 5_000.0
@@ -1733,7 +1681,7 @@ class EacTcoCalculatorTest(unittest.TestCase):
                     opex_annual=opex_annual,
                     technical_lifetime=technical_lifetime,
                 )
-                calc = CostCalculator(system)
+                calc = FinancialCalculator(system)
                 npv_zero = calc.calculate_npv(system_lifetime, discount_rate=0.0)
                 tco = calc.calculate_tco(system_lifetime)
                 self.assertAlmostEqual(tco, npv_zero, places=6)
@@ -1745,7 +1693,6 @@ class EacTcoCalculatorTest(unittest.TestCase):
         With technical_lifetime=20 and system_lifetime=30: ceil(30/20) = 2
         (you must buy a second asset at year 20 to keep the system running).
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 50_000.0
         system_lifetime = 30.0
@@ -1754,14 +1701,14 @@ class EacTcoCalculatorTest(unittest.TestCase):
         system_exact = self._make_system(
             investment=investment, opex_annual=0.0, technical_lifetime=10.0
         )
-        tco_exact = CostCalculator(system_exact).calculate_tco(system_lifetime)
+        tco_exact = FinancialCalculator(system_exact).calculate_tco(system_lifetime)
         self.assertAlmostEqual(tco_exact, 3.0 * investment, places=2)
 
         # Fractional ratio — ceil gives 2, continuous would give 1.5
         system_frac = self._make_system(
             investment=investment, opex_annual=0.0, technical_lifetime=20.0
         )
-        tco_frac = CostCalculator(system_frac).calculate_tco(system_lifetime)
+        tco_frac = FinancialCalculator(system_frac).calculate_tco(system_lifetime)
         self.assertAlmostEqual(tco_frac, 2.0 * investment, places=2)
 
     def test_tco_continuous_factor_uses_max_fraction(self) -> None:
@@ -1771,12 +1718,11 @@ class EacTcoCalculatorTest(unittest.TestCase):
         matching optimizers such as MESIDO's MinimizeTCO goal (which uses this
         approximation to keep the objective smooth and differentiable).
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 50_000.0
         system_lifetime = 30.0
         system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=20.0)
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         tco_default = calc.calculate_tco(system_lifetime)
         tco_continuous = calc.calculate_tco(system_lifetime, round_up_replacement=False)
@@ -1789,11 +1735,10 @@ class EacTcoCalculatorTest(unittest.TestCase):
 
         ceil(10/40) = 1 — the asset is bought once and not replaced.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
 
         investment = 80_000.0
         system = self._make_system(investment=investment, opex_annual=0.0, technical_lifetime=40.0)
-        tco = CostCalculator(system).calculate_tco(system_lifetime=10.0)
+        tco = FinancialCalculator(system).calculate_tco(system_lifetime=10.0)
         self.assertAlmostEqual(tco, investment, places=2)
 
     def test_tco_greater_than_npv_with_positive_discount_rate(self) -> None:
@@ -1802,13 +1747,11 @@ class EacTcoCalculatorTest(unittest.TestCase):
         NPV discounts future costs to present value (making them smaller), while
         TCO sums them at face value.  So TCO >= NPV for any positive discount rate.
         """
-        from kpicalculator.calculators.cost_calculator import CostCalculator
-
         system_lifetime = 30.0
         system = self._make_system(
             investment=100_000.0, opex_annual=5_000.0, technical_lifetime=40.0
         )
-        calc = CostCalculator(system)
+        calc = FinancialCalculator(system)
 
         tco = calc.calculate_tco(system_lifetime)
         npv = calc.calculate_npv(system_lifetime, discount_rate=5.0)
@@ -1822,9 +1765,454 @@ class EacTcoCalculatorTest(unittest.TestCase):
         kpi_manager.load_from_esdl(str(esdl_file))
         results = kpi_manager.calculate_all_kpis(system_lifetime=30)
 
-        self.assertIn("tco", results["costs"])
-        self.assertIsInstance(results["costs"]["tco"], float)
-        self.assertGreater(results["costs"]["tco"], 0.0)
+        self.assertIn("tco", results["financials"])
+        self.assertIsInstance(results["financials"]["tco"], float)
+        self.assertGreater(results["financials"]["tco"], 0.0)
+
+
+class AssetFinancialBreakdownTest(unittest.TestCase):
+    """Tests for FinancialCalculator.get_asset_financial_breakdown() and aggregate_by_category().
+
+    Uses a minimal synthetic EnergySystem to avoid file I/O and pin exact expected values.
+    """
+
+    _REQUIRED_KEYS = (
+        "investment_cost",
+        "installation_cost",
+        "fixed_operational_cost",
+        "variable_operational_cost",
+        "fixed_maintenance_cost",
+        "variable_maintenance_cost",
+        "annualized_capex",
+        "eac",
+        "npv",
+        "tco",
+        "lcoe",
+    )
+
+    def _make_system(
+        self,
+        asset_type: AssetType | None = None,
+        investment: float = 100_000.0,
+        opex_annual: float = 5_000.0,
+        technical_lifetime: float = 40.0,
+        asset_id: str = "asset_1",
+    ) -> "EnergySystem":
+        from kpicalculator.adapters.common_model import Asset, AssetType, EnergySystem
+
+        if asset_type is None:
+            asset_type = AssetType.CONSUMER
+        asset = Asset(
+            id=asset_id,
+            name="Test Asset",
+            asset_type=asset_type,
+            investment_cost=investment,
+            investment_cost_unit="EUR",
+            fixed_operational_cost=opex_annual,
+            fixed_operational_cost_unit="EUR/yr",
+            technical_lifetime=technical_lifetime,
+        )
+        return EnergySystem(name="Test System", assets=[asset])
+
+    # --- get_asset_financial_breakdown() ---
+
+    def test_returns_dict_keyed_by_asset_id(self) -> None:
+        """Result is a dict keyed by asset ID for every asset in the system."""
+
+        system = self._make_system(asset_id="my_asset")
+        breakdown = FinancialCalculator(system).get_asset_financial_breakdown(system_lifetime=30.0)
+
+        self.assertIn("my_asset", breakdown)
+        self.assertEqual(len(breakdown), 1)
+
+    def test_result_has_all_required_keys(self) -> None:
+        """Each AssetFinancialResult contains all 11 required keys."""
+
+        system = self._make_system()
+        breakdown = FinancialCalculator(system).get_asset_financial_breakdown(system_lifetime=30.0)
+        entry = next(iter(breakdown.values()))
+
+        for key in self._REQUIRED_KEYS:
+            with self.subTest(key=key):
+                self.assertIn(key, entry)
+
+    def test_lcoe_is_none_for_non_producing_asset(self) -> None:
+        """lcoe is None for consumer, storage, transport, and conversion assets."""
+        from kpicalculator.adapters.common_model import AssetType
+
+        for asset_type in (AssetType.CONSUMER, AssetType.STORAGE, AssetType.TRANSPORT):
+            with self.subTest(asset_type=asset_type):
+                system = self._make_system(asset_type=asset_type)
+                breakdown = FinancialCalculator(system).get_asset_financial_breakdown(
+                    system_lifetime=30.0
+                )
+                self.assertIsNone(next(iter(breakdown.values()))["lcoe"])
+
+    def test_lcoe_is_none_for_producer_without_energy_data(self) -> None:
+        """lcoe is None for a producer when annual_energy_mwh_by_asset=None."""
+        from kpicalculator.adapters.common_model import AssetType
+
+        system = self._make_system(asset_type=AssetType.PRODUCER)
+        breakdown = FinancialCalculator(system).get_asset_financial_breakdown(
+            system_lifetime=30.0, annual_energy_mwh_by_asset=None
+        )
+        self.assertIsNone(next(iter(breakdown.values()))["lcoe"])
+
+    def test_lcoe_is_computed_for_producer_with_energy_data(self) -> None:
+        """lcoe is non-None for a producer when annual energy is supplied and non-zero."""
+        from kpicalculator.adapters.common_model import AssetType
+
+        system = self._make_system(asset_type=AssetType.PRODUCER, asset_id="prod_1")
+        breakdown = FinancialCalculator(system).get_asset_financial_breakdown(
+            system_lifetime=30.0,
+            discount_rate=5.0,
+            annual_energy_mwh_by_asset={"prod_1": 8_760.0},
+        )
+        lcoe = next(iter(breakdown.values()))["lcoe"]
+        self.assertIsNotNone(lcoe)
+        self.assertGreater(lcoe, 0.0)
+
+    def test_npv_sum_matches_calculate_npv(self) -> None:
+        """Sum of per-asset NPVs equals FinancialCalculator.calculate_npv()."""
+
+        system = self._make_system()
+        calc = FinancialCalculator(system)
+        system_lifetime = 30.0
+        discount_rate = 5.0
+
+        breakdown = calc.get_asset_financial_breakdown(system_lifetime, discount_rate)
+        npv_from_breakdown = sum(r["npv"] for r in breakdown.values())
+        npv_direct = calc.calculate_npv(system_lifetime, discount_rate)
+
+        self.assertAlmostEqual(npv_from_breakdown, npv_direct, places=6)
+
+    def test_eac_sum_matches_calculate_eac(self) -> None:
+        """Sum of per-asset EACs equals FinancialCalculator.calculate_eac()."""
+
+        system = self._make_system()
+        calc = FinancialCalculator(system)
+        discount_rate = 5.0
+
+        breakdown = calc.get_asset_financial_breakdown(
+            system_lifetime=30.0, discount_rate=discount_rate
+        )
+        eac_from_breakdown = sum(r["eac"] for r in breakdown.values())
+        eac_direct = calc.calculate_eac(discount_rate)
+
+        self.assertAlmostEqual(eac_from_breakdown, eac_direct, places=6)
+
+    def test_tco_sum_matches_calculate_tco(self) -> None:
+        """Sum of per-asset TCOs equals FinancialCalculator.calculate_tco()."""
+
+        system = self._make_system()
+        calc = FinancialCalculator(system)
+        system_lifetime = 30.0
+
+        breakdown = calc.get_asset_financial_breakdown(system_lifetime)
+        tco_from_breakdown = sum(r["tco"] for r in breakdown.values())
+        tco_direct = calc.calculate_tco(system_lifetime)
+
+        self.assertAlmostEqual(tco_from_breakdown, tco_direct, places=6)
+
+    def test_invalid_system_lifetime_raises_calculation_error(self) -> None:
+        """get_asset_financial_breakdown() raises CalculationError for system_lifetime <= 0."""
+        from kpicalculator.exceptions import CalculationError
+
+        calc = FinancialCalculator(self._make_system())
+
+        with self.assertRaises(CalculationError):
+            calc.get_asset_financial_breakdown(system_lifetime=0.0)
+
+        with self.assertRaises(CalculationError):
+            calc.get_asset_financial_breakdown(system_lifetime=-1.0)
+
+    def test_invalid_discount_rate_raises_calculation_error(self) -> None:
+        """get_asset_financial_breakdown() raises CalculationError for invalid discount_rate."""
+        from kpicalculator.exceptions import CalculationError
+
+        calc = FinancialCalculator(self._make_system())
+
+        with self.assertRaises(CalculationError):
+            calc.get_asset_financial_breakdown(system_lifetime=30.0, discount_rate=-1.0)
+
+        with self.assertRaises(CalculationError):
+            calc.get_asset_financial_breakdown(system_lifetime=30.0, discount_rate=101.0)
+
+    def test_zero_technical_lifetime_raises_calculation_error(self) -> None:
+        """get_asset_financial_breakdown() raises CalculationError for technical_lifetime <= 0."""
+        from kpicalculator.adapters.common_model import Asset, AssetType, EnergySystem
+        from kpicalculator.exceptions import CalculationError
+
+        asset = Asset(
+            id="bad",
+            name="Bad",
+            asset_type=AssetType.CONSUMER,
+            investment_cost=0.0,
+            investment_cost_unit="EUR",
+            technical_lifetime=0.0,
+        )
+        system = EnergySystem(name="S", assets=[asset])
+
+        with self.assertRaises(CalculationError):
+            FinancialCalculator(system).get_asset_financial_breakdown(system_lifetime=30.0)
+
+    # --- aggregate_by_category() ---
+
+    def test_aggregate_by_category_returns_tuple_of_two_dicts(self) -> None:
+        """aggregate_by_category() returns (capex_dict, opex_dict)."""
+
+        system = self._make_system()
+        calc = FinancialCalculator(system)
+        breakdown = calc.get_asset_financial_breakdown(system_lifetime=30.0)
+        result = calc.aggregate_by_category(breakdown)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        capex, opex = result
+        self.assertIsInstance(capex, dict)
+        self.assertIsInstance(opex, dict)
+
+    def test_aggregate_by_category_has_expected_keys(self) -> None:
+        """Both dicts include 'All' and the five named categories."""
+
+        system = self._make_system()
+        calc = FinancialCalculator(system)
+        breakdown = calc.get_asset_financial_breakdown(system_lifetime=30.0)
+        capex, opex = calc.aggregate_by_category(breakdown)
+
+        expected_keys = {"Production", "Consumption", "Storage", "Transport", "Conversion", "All"}
+        self.assertEqual(set(capex.keys()), expected_keys)
+        self.assertEqual(set(opex.keys()), expected_keys)
+
+    def test_aggregate_all_equals_sum_of_categories(self) -> None:
+        """'All' equals the sum of the five named category values."""
+        from kpicalculator.adapters.common_model import Asset, AssetType, EnergySystem
+
+        assets = [
+            Asset(
+                id="p1",
+                name="P",
+                asset_type=AssetType.PRODUCER,
+                investment_cost=10_000.0,
+                investment_cost_unit="EUR",
+                fixed_operational_cost=500.0,
+                technical_lifetime=20.0,
+            ),
+            Asset(
+                id="c1",
+                name="C",
+                asset_type=AssetType.CONSUMER,
+                investment_cost=5_000.0,
+                investment_cost_unit="EUR",
+                fixed_operational_cost=200.0,
+                technical_lifetime=20.0,
+            ),
+        ]
+        system = EnergySystem(name="S", assets=assets)
+        calc = FinancialCalculator(system)
+        breakdown = calc.get_asset_financial_breakdown(system_lifetime=30.0)
+        capex, opex = calc.aggregate_by_category(breakdown)
+
+        named_categories = ["Production", "Consumption", "Storage", "Transport", "Conversion"]
+        self.assertAlmostEqual(capex["All"], sum(capex[k] for k in named_categories), places=6)
+        self.assertAlmostEqual(opex["All"], sum(opex[k] for k in named_categories), places=6)
+
+    def test_aggregate_empty_system_returns_zeros(self) -> None:
+        """aggregate_by_category() on an empty system returns all-zero dicts without error.
+
+        An empty system (zero assets) is a legitimate edge case — get_asset_financial_breakdown()
+        returns {} for it, and aggregate_by_category({}) must return zeros cleanly.
+        """
+        from kpicalculator.adapters.common_model import EnergySystem
+
+        system = EnergySystem(name="S", assets=[])
+        calc = FinancialCalculator(system)
+        breakdown = calc.get_asset_financial_breakdown(system_lifetime=30.0)
+        capex, opex = calc.aggregate_by_category(breakdown)
+
+        for key in capex:
+            self.assertEqual(capex[key], 0.0)
+        for key in opex:
+            self.assertEqual(opex[key], 0.0)
+
+    # --- asset_financials in KpiResults ---
+
+    def test_calculate_all_kpis_includes_asset_financials(self) -> None:
+        """calculate_all_kpis() result includes 'asset_financials' keyed by asset ID."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0)
+
+        self.assertIn("asset_financials", results)
+        self.assertIsInstance(results["asset_financials"], dict)
+        self.assertGreater(len(results["asset_financials"]), 0)
+
+    def test_asset_financial_result_has_all_required_keys(self) -> None:
+        """Every entry in asset_financials contains all 11 AssetFinancialResult keys."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0)
+
+        for asset_id, entry in results["asset_financials"].items():
+            for key in self._REQUIRED_KEYS:
+                with self.subTest(asset_id=asset_id, key=key):
+                    self.assertIn(key, entry)
+
+    def test_asset_npv_sum_equals_system_npv(self) -> None:
+        """Sum of per-asset NPVs equals the system-level NPV in financials."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0, discount_rate=5.0)
+
+        asset_npv_sum = sum(r["npv"] for r in results["asset_financials"].values())
+        system_npv = results["financials"]["npv"]
+
+        self.assertAlmostEqual(asset_npv_sum, system_npv, places=4)
+
+    def test_asset_eac_sum_equals_system_eac(self) -> None:
+        """Sum of per-asset EACs equals the system-level EAC in financials."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0, discount_rate=5.0)
+
+        asset_eac_sum = sum(r["eac"] for r in results["asset_financials"].values())
+        system_eac = results["financials"]["eac"]
+
+        self.assertAlmostEqual(asset_eac_sum, system_eac, places=4)
+
+    def test_asset_tco_sum_equals_system_tco(self) -> None:
+        """Sum of per-asset TCOs equals the system-level TCO in financials."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0)
+
+        asset_tco_sum = sum(r["tco"] for r in results["asset_financials"].values())
+        system_tco = results["financials"]["tco"]
+
+        self.assertAlmostEqual(asset_tco_sum, system_tco, places=4)
+
+
+class PerAssetLcoeTest(unittest.TestCase):
+    """Tests for per-asset LCOE computation in KpiManager.calculate_all_kpis().
+
+    Per-asset LCOE is computed inside FinancialCalculator.get_asset_financial_breakdown()
+    when annual energy data is supplied. KpiManager pre-computes the energy dict from
+    EnergyCalculator and passes it in; FinancialCalculator never imports EnergyCalculator.
+    """
+
+    def _make_producer_system_with_timeseries(self) -> tuple["KpiManager", str]:
+        """Load the standard ESDL fixture with a real time series for energy data."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        series_file = DATA_DIR / "power_timeseries.xml"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file), time_series_file=str(series_file))
+        return kpi_manager, str(esdl_file)
+
+    def test_lcoe_filled_for_producing_assets_with_energy(self) -> None:
+        """Producer assets with non-zero energy production get a non-None lcoe value."""
+
+        # GenericConsumer asset — use a producer asset ID from the fixture if available,
+        # but the fixture may only have consumer assets. We verify the contract:
+        # if an asset IS a producer type AND has energy > 0, lcoe must not be None.
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(
+            str(esdl_file), time_series_file=str(DATA_DIR / "power_timeseries.xml")
+        )
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0)
+
+        from kpicalculator.calculators.financial_calculator import PRODUCER_ASSET_TYPES
+
+        # For any producer asset that has a non-None, non-zero lcoe, verify it's positive
+        producer_ids = {
+            a.id for a in kpi_manager.energy_system.assets if a.asset_type in PRODUCER_ASSET_TYPES
+        }
+        for asset_id, entry in results["asset_financials"].items():
+            if asset_id in producer_ids and entry["lcoe"] is not None:
+                self.assertGreater(
+                    entry["lcoe"],
+                    0.0,
+                    f"LCOE for producer asset {asset_id} must be positive when set",
+                )
+
+    def test_lcoe_none_for_non_producing_assets(self) -> None:
+        """Non-producing assets (consumers, storage, transport) always have lcoe=None."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(
+            str(esdl_file), time_series_file=str(DATA_DIR / "power_timeseries.xml")
+        )
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0)
+
+        from kpicalculator.calculators.financial_calculator import PRODUCER_ASSET_TYPES
+
+        producer_ids = {
+            a.id for a in kpi_manager.energy_system.assets if a.asset_type in PRODUCER_ASSET_TYPES
+        }
+        for asset_id, entry in results["asset_financials"].items():
+            if asset_id not in producer_ids:
+                self.assertIsNone(
+                    entry["lcoe"],
+                    f"Non-producing asset {asset_id} must have lcoe=None",
+                )
+
+    def test_lcoe_none_when_no_time_series(self) -> None:
+        """Without time series data, all assets have lcoe=None (zero energy production)."""
+        esdl_file = DATA_DIR / "Unit_test_ESDL.esdl"
+        kpi_manager = KpiManager()
+        kpi_manager.load_from_esdl(str(esdl_file))  # no time series
+        results = kpi_manager.calculate_all_kpis(system_lifetime=30.0)
+
+        for asset_id, entry in results["asset_financials"].items():
+            self.assertIsNone(
+                entry["lcoe"],
+                f"Asset {asset_id} must have lcoe=None when no time series provided",
+            )
+
+    def test_per_asset_lcoe_formula_npv_over_discounted_energy(self) -> None:
+        """Per-asset LCOE equals per-asset NPV divided by discounted energy production.
+
+        At r=0: NPV = CAPEX + OPEX * system_lifetime,
+                discounted_energy = annual_mwh * system_lifetime,
+                so lcoe = (CAPEX + OPEX * n) / (annual_mwh * n).
+        Verified by calling FinancialCalculator directly with a known energy dict.
+        """
+        from kpicalculator.adapters.common_model import Asset, AssetType, EnergySystem
+
+        system_lifetime = 10.0
+        investment = 100_000.0
+        opex_annual = 5_000.0
+        annual_energy_mwh = 8_760.0  # 1 MW continuously for one year
+
+        asset = Asset(
+            id="prod",
+            name="Producer",
+            asset_type=AssetType.PRODUCER,
+            investment_cost=investment,
+            investment_cost_unit="EUR",
+            fixed_operational_cost=opex_annual,
+            fixed_operational_cost_unit="EUR/yr",
+            technical_lifetime=40.0,
+        )
+        system = EnergySystem(name="S", assets=[asset])
+        calc = FinancialCalculator(system)
+        breakdown = calc.get_asset_financial_breakdown(
+            system_lifetime=system_lifetime,
+            discount_rate=0.0,
+            annual_energy_mwh_by_asset={"prod": annual_energy_mwh},
+        )
+
+        lcoe = breakdown["prod"]["lcoe"]
+        expected_npv = investment + opex_annual * system_lifetime
+        expected_lcoe = expected_npv / (annual_energy_mwh * system_lifetime)
+
+        self.assertIsNotNone(lcoe)
+        self.assertAlmostEqual(lcoe, expected_lcoe, places=6)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -558,7 +558,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "filelock", specifier = ">=3.20.1" },
+    { name = "filelock", specifier = ">=3.25.0" },
     { name = "influxdb", specifier = ">=5.3.2" },
     { name = "numpy", specifier = ">=2.1.0,<3.0" },
     { name = "pandas", specifier = ">=2.2.2,<3.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -64,21 +64,6 @@ wheels = [
 ]
 
 [[package]]
-name = "bandit"
-version = "1.8.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "pyyaml" },
-    { name = "rich" },
-    { name = "stevedore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/b5/7eb834e213d6f73aace21938e5e90425c92e5f42abafaf8a6d5d21beed51/bandit-1.8.6.tar.gz", hash = "sha256:dbfe9c25fc6961c2078593de55fd19f2559f9e45b99f1272341f5b95dea4e56b", size = 4240271, upload-time = "2025-07-06T03:10:50.9Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/ca/ba5f909b40ea12ec542d5d7bdd13ee31c4d65f3beed20211ef81c18fa1f3/bandit-1.8.6-py3-none-any.whl", hash = "sha256:3348e934d736fcdb68b6aa4030487097e23a501adf3e7827b63658df464dddd0", size = 133808, upload-time = "2025-07-06T03:10:49.134Z" },
-]
-
-[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -228,18 +213,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
-]
-
-[[package]]
-name = "coloredlogs"
-version = "15.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "humanfriendly" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
 ]
 
 [[package]]
@@ -418,18 +391,6 @@ wheels = [
 ]
 
 [[package]]
-name = "humanfriendly"
-version = "10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
-]
-
-[[package]]
 name = "hypothesis"
 version = "6.139.2"
 source = { registry = "https://pypi.org/simple" }
@@ -519,27 +480,22 @@ wheels = [
 name = "kpi-calculator"
 source = { editable = "." }
 dependencies = [
-    { name = "coloredlogs" },
     { name = "filelock" },
     { name = "influxdb" },
     { name = "numpy" },
     { name = "pandas" },
-    { name = "pandas-stubs" },
     { name = "pydantic" },
     { name = "pyesdl" },
-    { name = "types-xmltodict" },
     { name = "urllib3" },
     { name = "xmltodict" },
 ]
 
 [package.dev-dependencies]
 analysis = [
-    { name = "bandit" },
     { name = "codespell" },
     { name = "pip-audit" },
     { name = "pipdeptree" },
     { name = "pylint" },
-    { name = "radon" },
     { name = "vulture" },
 ]
 build = [
@@ -551,13 +507,13 @@ build = [
     { name = "wheel" },
 ]
 dev = [
-    { name = "bandit" },
     { name = "build" },
     { name = "bump2version" },
     { name = "codespell" },
     { name = "furo" },
     { name = "hypothesis" },
     { name = "mypy" },
+    { name = "pandas-stubs" },
     { name = "pip" },
     { name = "pip-audit" },
     { name = "pipdeptree" },
@@ -566,7 +522,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-xdist" },
-    { name = "radon" },
     { name = "ruff" },
     { name = "setuptools" },
     { name = "setuptools-git-versioning" },
@@ -575,6 +530,7 @@ dev = [
     { name = "sphinx-autodoc-typehints", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx-autodoc-typehints", version = "3.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-copybutton" },
+    { name = "types-xmltodict" },
     { name = "vulture" },
     { name = "wheel" },
 ]
@@ -588,8 +544,10 @@ docs = [
 ]
 lint = [
     { name = "mypy" },
+    { name = "pandas-stubs" },
     { name = "pre-commit" },
     { name = "ruff" },
+    { name = "types-xmltodict" },
 ]
 test = [
     { name = "hypothesis" },
@@ -600,27 +558,22 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "coloredlogs", specifier = "~=15.0.1" },
     { name = "filelock", specifier = ">=3.20.1" },
     { name = "influxdb", specifier = ">=5.3.2" },
     { name = "numpy", specifier = ">=2.1.0,<3.0" },
     { name = "pandas", specifier = ">=2.2.2,<3.0" },
-    { name = "pandas-stubs" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0" },
     { name = "pyesdl", specifier = "~=25.7" },
-    { name = "types-xmltodict" },
     { name = "urllib3", specifier = ">=2.6.3" },
     { name = "xmltodict", specifier = "==0.14.2" },
 ]
 
 [package.metadata.requires-dev]
 analysis = [
-    { name = "bandit", specifier = ">=1.7.0" },
     { name = "codespell", specifier = ">=2.0.0" },
     { name = "pip-audit", specifier = ">=2.0.0" },
     { name = "pipdeptree", specifier = ">=2.0.0" },
     { name = "pylint", specifier = ">=3.0.0" },
-    { name = "radon", specifier = ">=6.0.0" },
     { name = "vulture", specifier = ">=2.0.0" },
 ]
 build = [
@@ -632,13 +585,13 @@ build = [
     { name = "wheel", specifier = "~=0.46.2" },
 ]
 dev = [
-    { name = "bandit", specifier = ">=1.7.0" },
     { name = "build", specifier = "~=1.0.3" },
     { name = "bump2version", specifier = "==1.0.1" },
     { name = "codespell", specifier = ">=2.0.0" },
     { name = "furo", specifier = ">=2023.1.0" },
     { name = "hypothesis", specifier = ">=6.0.0" },
     { name = "mypy", specifier = "~=1.5.1" },
+    { name = "pandas-stubs" },
     { name = "pip", specifier = ">=25.3" },
     { name = "pip-audit", specifier = ">=2.0.0" },
     { name = "pipdeptree", specifier = ">=2.0.0" },
@@ -647,13 +600,13 @@ dev = [
     { name = "pytest", specifier = "~=7.3.1" },
     { name = "pytest-cov", specifier = "~=4.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.0" },
-    { name = "radon", specifier = ">=6.0.0" },
     { name = "ruff", specifier = ">=0.6.0" },
     { name = "setuptools", specifier = ">=70.0.0" },
     { name = "setuptools-git-versioning", specifier = "<2" },
     { name = "sphinx", specifier = ">=5.3" },
     { name = "sphinx-autodoc-typehints", specifier = ">=1.18.0" },
     { name = "sphinx-copybutton", specifier = ">=0.5.0" },
+    { name = "types-xmltodict" },
     { name = "vulture", specifier = ">=2.0.0" },
     { name = "wheel", specifier = "~=0.46.2" },
 ]
@@ -665,8 +618,10 @@ docs = [
 ]
 lint = [
     { name = "mypy", specifier = "~=1.5.1" },
+    { name = "pandas-stubs" },
     { name = "pre-commit", specifier = "~=3.6.0" },
     { name = "ruff", specifier = ">=0.6.0" },
+    { name = "types-xmltodict" },
 ]
 test = [
     { name = "hypothesis", specifier = ">=6.0.0" },
@@ -767,18 +722,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/ea/048dea6cdfc7a72d40ae8ed7e7d23cf4a6b6a6547b51b492a3be50af0e80/lxml-6.0.1-pp311-pypy311_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:445f2cee71c404ab4259bc21e20339a859f75383ba2d7fb97dfe7c163994287b", size = 4270228, upload-time = "2025-08-22T10:37:47.276Z" },
     { url = "https://files.pythonhosted.org/packages/6b/d4/c2b46e432377c45d611ae2f669aa47971df1586c1a5240675801d0f02bac/lxml-6.0.1-pp311-pypy311_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e352d8578e83822d70bea88f3d08b9912528e4c338f04ab707207ab12f4b7aac", size = 4416077, upload-time = "2025-08-22T10:37:49.822Z" },
     { url = "https://files.pythonhosted.org/packages/b6/db/8f620f1ac62cf32554821b00b768dd5957ac8e3fd051593532be5b40b438/lxml-6.0.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:51bd5d1a9796ca253db6045ab45ca882c09c071deafffc22e06975b7ace36300", size = 3518127, upload-time = "2025-08-22T10:37:51.66Z" },
-]
-
-[[package]]
-name = "mando"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/35/24/cd70d5ae6d35962be752feccb7dca80b5e0c2d450e995b16abd6275f3296/mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500", size = 37868, upload-time = "2022-02-24T08:12:27.316Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/f0/834e479e47e499b6478e807fb57b31cc2db696c4db30557bb6f5aea4a90b/mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a", size = 28149, upload-time = "2022-02-24T08:12:25.24Z" },
 ]
 
 [[package]]
@@ -1359,15 +1302,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyreadline3"
-version = "3.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/49/4cea918a08f02817aabae639e3d0ac046fef9f9180518a3ad394e22da148/pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7", size = 99839, upload-time = "2024-09-19T02:40:10.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/dc/491b7661614ab97483abf2056be1deee4dc2490ecbf7bff9ab5cdbac86e1/pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6", size = 83178, upload-time = "2024-09-19T02:40:08.598Z" },
-]
-
-[[package]]
 name = "pytest"
 version = "7.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1475,19 +1409,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
-]
-
-[[package]]
-name = "radon"
-version = "6.0.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama" },
-    { name = "mando" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/6d/98e61600febf6bd929cf04154537c39dc577ce414bafbfc24a286c4fa76d/radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5", size = 1874992, upload-time = "2023-03-26T06:24:38.868Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/f7/d00d9b4a0313a6be3a3e0818e6375e15da6d7076f4ae47d1324e7ca986a1/radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859", size = 52784, upload-time = "2023-03-26T06:24:33.949Z" },
 ]
 
 [[package]]
@@ -1790,15 +1711,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
-]
-
-[[package]]
-name = "stevedore"
-version = "5.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/5f/8418daad5c353300b7661dd8ce2574b0410a6316a8be650a189d5c68d938/stevedore-5.5.0.tar.gz", hash = "sha256:d31496a4f4df9825e1a1e4f1f74d19abb0154aff311c3b376fcc89dae8fccd73", size = 513878, upload-time = "2025-08-25T12:54:26.806Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/80/c5/0c06759b95747882bb50abda18f5fb48c3e9b0fbfc6ebc0e23550b52415d/stevedore-5.5.0-py3-none-any.whl", hash = "sha256:18363d4d268181e8e8452e71a38cd77630f345b2ef6b4a8d5614dac5ee0d18cf", size = 49518, upload-time = "2025-08-25T12:54:25.445Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -384,11 +384,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.20.2"
+version = "3.25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c1/e0/a75dbe4bca1e7d41307323dad5ea2efdd95408f74ab2de8bd7dba9b51a1a/filelock-3.20.2.tar.gz", hash = "sha256:a2241ff4ddde2a7cebddf78e39832509cb045d18ec1a09d7248d6bfc6bfbbe64", size = 19510, upload-time = "2026-01-02T15:33:32.582Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz", hash = "sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3", size = 40158, upload-time = "2026-03-01T15:08:45.916Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/30/ab407e2ec752aa541704ed8f93c11e2a5d92c168b8a755d818b74a3c5c2d/filelock-3.20.2-py3-none-any.whl", hash = "sha256:fbba7237d6ea277175a32c54bb71ef814a8546d8601269e1bfc388de333974e8", size = 16697, upload-time = "2026-01-02T15:33:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/0b/de6f54d4a8bedfe8645c41497f3c18d749f0bd3218170c667bf4b81d0cdd/filelock-3.25.0-py3-none-any.whl", hash = "sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047", size = 26427, upload-time = "2026-03-01T15:08:44.593Z" },
 ]
 
 [[package]]
@@ -1095,11 +1095,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "25.3"
+version = "26.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/6e/74a3f0179a4a73a53d66ce57fdb4de0080a8baa1de0063de206d6167acc2/pip-25.3.tar.gz", hash = "sha256:8d0538dbbd7babbd207f261ed969c65de439f6bc9e5dbd3b3b9a77f25d95f343", size = 1803014, upload-time = "2025-10-25T00:55:41.394Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/3c/d717024885424591d5376220b5e836c2d5293ce2011523c9de23ff7bf068/pip-25.3-py3-none-any.whl", hash = "sha256:9655943313a94722b7774661c21049070f6bbb0a1516bf02f7c8d5d9201514cd", size = 1778622, upload-time = "2025-10-25T00:55:39.247Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
 ]
 
 [[package]]
@@ -1418,6 +1418,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/bb/93a3e83bdf9322c7e21cafd092e56a4a17c4d8ef4277b6eb01af1a540a6f/python_discovery-1.1.0.tar.gz", hash = "sha256:447941ba1aed8cc2ab7ee3cb91be5fc137c5bdbb05b7e6ea62fbdcb66e50b268", size = 55674, upload-time = "2026-02-26T09:42:49.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/54/82a6e2ef37f0f23dccac604b9585bdcbd0698604feb64807dcb72853693e/python_discovery-1.1.0-py3-none-any.whl", hash = "sha256:a162893b8809727f54594a99ad2179d2ede4bf953e12d4c7abc3cc9cdbd1437b", size = 30687, upload-time = "2026-02-26T09:42:48.548Z" },
 ]
 
 [[package]]
@@ -1904,16 +1917,17 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "20.34.0"
+version = "21.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
     { name = "filelock" },
     { name = "platformdirs" },
+    { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1c/14/37fcdba2808a6c615681cd216fecae00413c9dab44fb2e57805ecf3eaee3/virtualenv-20.34.0.tar.gz", hash = "sha256:44815b2c9dee7ed86e387b842a84f20b93f7f417f95886ca1996a72a4138eb1a", size = 6003808, upload-time = "2025-08-13T14:24:07.464Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/c9/18d4b36606d6091844daa3bd93cf7dc78e6f5da21d9f21d06c221104b684/virtualenv-21.1.0.tar.gz", hash = "sha256:1990a0188c8f16b6b9cf65c9183049007375b26aad415514d377ccacf1e4fb44", size = 5840471, upload-time = "2026-02-27T08:49:29.702Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/06/04c8e804f813cf972e3262f3f8584c232de64f0cde9f703b46cf53a45090/virtualenv-20.34.0-py3-none-any.whl", hash = "sha256:341f5afa7eee943e4984a9207c025feedd768baff6753cd660c857ceb3e36026", size = 5983279, upload-time = "2025-08-13T14:24:05.111Z" },
+    { url = "https://files.pythonhosted.org/packages/78/55/896b06bf93a49bec0f4ae2a6f1ed12bd05c8860744ac3a70eda041064e4d/virtualenv-21.1.0-py3-none-any.whl", hash = "sha256:164f5e14c5587d170cf98e60378eb91ea35bf037be313811905d3a24ea33cc07", size = 5825072, upload-time = "2026-02-27T08:49:27.516Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
  
  - Adds EAC (Equivalent Annual Cost) and TCO (Total Cost of Ownership) as new
    system-level financial KPIs
  - Renames `CostCalculator` → `FinancialCalculator` to reflect the broader scope
  - Adds `asset_financials` to `KpiResults`: a per-asset breakdown of all financial
    KPIs (investment, installation, OPEX, annualized CAPEX, EAC, NPV, TCO, LCOE)
  - Per-asset discount rates from ESDL `costInformation.discountRate` are now
    respected by all discounted KPIs (NPV, LCOE, EAC, annualized CAPEX)
  - System LCOE is now computed as `sum(per-asset NPVs) / total_discounted_energy`,
    where per-asset NPVs use each asset's own discount rate
  - Exposes `discount_rate` as a parameter on `KpiManager.calculate_all_kpis()`
  - Exposes `round_up_replacement` on both `calculate_kpis()` and
    `calculate_all_kpis()` for MESIDO optimizer compatibility
  - Exports result TypedDicts (`KpiResults`, `FinancialResults`, `EnergyResults`,
    `EmissionResults`, `AssetFinancialResult`) as part of the public API
  - Enriches docstrings on all result types and key methods; reduces redundancy
    between docstrings and user documentation
  - Add calculate_kpis_from_simulator() and build_esdl_string_with_kpis() as
  standalone functions so callers need no knowledge of KpiManager internals.
  EsdlKpiExporter.export() now takes esdl.EnergySystem directly, removing
  the coupling to the common model and the KpiManager state-swap workaround.
  Simulator worker updated to use the public API only; fixes a semantic bug
  where output_esdl (no cost data) was passed instead of input_esdl.

To be merged after #35 